### PR TITLE
feat: implement Clone Hero .sng export

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import icon from '../../resources/icon.png?asset'
 import ffmpeg from 'fluent-ffmpeg'
 import { cancelAutoChart, getStrumRequirementsPath, killAllRunningJobs, openStrumLogsFolder, resolvePythonCommand, runAutoChart } from './strumIntegration/runner'
 import { ensureBootstrappedPython, getRuntimeStatus, isBootstrapTarget } from './strumIntegration/runtimeBootstrap'
+import { packSng } from './sngPacker'
 
 // Point fluent-ffmpeg at the bundled static binary
 try {
@@ -630,6 +631,34 @@ ipcMain.handle('dialog:openOutputFolder', async () => {
   return result.filePaths[0]
 })
 
+// Reveal file in OS file explorer
+ipcMain.handle('dialog:showItemInFolder', async (_event, filePath: string) => {
+  try {
+    const resolvedPath = resolve(filePath)
+    
+    // Validate path exists and is a file
+    const fStat = await stat(resolvedPath)
+    if (!fStat.isFile()) {
+      return false
+    }
+
+    // Safety check: must be a .sng export or belong to the active project folder
+    const isSng = resolvedPath.toLowerCase().endsWith('.sng')
+    const isProjectFile = allowedProjectPath && (resolvedPath === allowedProjectPath || resolvedPath.startsWith(allowedProjectPath + '/') || resolvedPath.startsWith(allowedProjectPath + '\\'))
+    
+    if (!isSng && !isProjectFile) {
+      console.warn('[Security] Refusing to reveal path outside allowed boundaries:', resolvedPath)
+      return false
+    }
+
+    shell.showItemInFolder(resolvedPath)
+    return true
+  } catch (error) {
+    console.error('Error showing item in folder:', error)
+    return false
+  }
+})
+
 ipcMain.handle('strum:getDefaultOutputFolder', async () => {
   const defaultOutputFolder = join(app.getPath('documents'), 'OCTAVE', 'Auto-Chart Output')
   await mkdir(defaultOutputFolder, { recursive: true })
@@ -1018,6 +1047,36 @@ ipcMain.handle('song:writeChart', async (_event, songPath: string, chartText: st
     console.error('Error writing notes.chart:', error)
     try { if (existsSync(tempPath)) await unlink(tempPath) } catch { /* ignore */ }
     return false
+  }
+})
+
+// Export song to .sng package
+ipcMain.handle('song:exportSng', async (_event, songPath: string, metadata: Record<string, unknown>, outputPath: string) => {
+  if (!isPathAllowed(songPath)) {
+    return { success: false, error: 'Path to song directory not allowed' }
+  }
+
+  const resolvedOutput = resolve(outputPath)
+  if (!resolvedOutput.toLowerCase().endsWith('.sng')) {
+    return { success: false, error: 'Output path must end with .sng extension' }
+  }
+
+  const parentDir = resolve(resolvedOutput, '..')
+  try {
+    const parentStat = await stat(parentDir)
+    if (!parentStat.isDirectory()) {
+      return { success: false, error: 'Output directory does not exist' }
+    }
+  } catch {
+    return { success: false, error: 'Output directory does not exist or is inaccessible' }
+  }
+
+  try {
+    await packSng(songPath, metadata as Record<string, string | number | boolean>, resolvedOutput)
+    return { success: true }
+  } catch (error) {
+    console.error('Error packing SNG:', error)
+    return { success: false, error: error instanceof Error ? error.message : String(error) }
   }
 })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1080,6 +1080,17 @@ ipcMain.handle('song:exportSng', async (_event, songPath: string, metadata: Reco
   }
 })
 
+// Check if a file exists
+ipcMain.handle('fs:fileExists', async (_event, filePath: string) => {
+  try {
+    const resolvedPath = resolve(filePath)
+    const s = await stat(resolvedPath)
+    return s.isFile()
+  } catch {
+    return false
+  }
+})
+
 // Read video.json (video sync/clip data)
 ipcMain.handle('video:readJson', async (_event, songPath: string) => {
   if (!isPathAllowed(songPath)) return null

--- a/src/main/sngPacker.test.ts
+++ b/src/main/sngPacker.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { packSng } from './sngPacker'
+import { join } from 'path'
+import { mkdir, writeFile, readFile, rm } from 'fs/promises'
+import { existsSync } from 'fs'
+
+// Mock fs/promises to simulate long filenames that the OS might prevent writing directly
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>()
+  return {
+    ...actual,
+    readdir: async (path: string, options?: any) => {
+      if (String(path).includes('bad_song_long_name')) {
+        return ['notes.chart', 'a'.repeat(260) + '.ogg']
+      }
+      return actual.readdir(path, options)
+    },
+    readFile: async (path: string, options?: any) => {
+      if (String(path).includes('bad_song_long_name') && String(path).includes('a'.repeat(260))) {
+        return Buffer.from('MOCK DATA')
+      }
+      return actual.readFile(path, options)
+    }
+  }
+})
+
+// Mock fs to simulate stats for the simulated long filename
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    statSync: (path: string) => {
+      if (String(path).includes('bad_song_long_name') && String(path).includes('a'.repeat(260))) {
+        return { isFile: () => true, size: 100 } as any
+      }
+      return actual.statSync(path)
+    }
+  }
+})
+
+describe('sngPacker', () => {
+  const testDir = join(__dirname, '../../out/sng_test_temp')
+
+  beforeAll(async () => {
+    await mkdir(testDir, { recursive: true })
+  })
+
+  afterAll(async () => {
+    if (existsSync(testDir)) {
+      await rm(testDir, { recursive: true, force: true })
+    }
+  })
+
+  it('packs a folder into .sng package and validates the output structure', async () => {
+    const songDir = join(testDir, 'my_song')
+    await mkdir(songDir, { recursive: true })
+
+    // Create mock song files
+    await writeFile(join(songDir, 'song.ini'), '[Song]\nname = Test Song\n') // should be ignored
+    await writeFile(join(songDir, 'notes.chart'), '[Song]\n{\n  Resolution = 192\n}\n')
+    await writeFile(join(songDir, 'guitar.ogg'), 'OGG MOCK DATA')
+    await writeFile(join(songDir, 'desktop.ini'), 'ignore this') // should be ignored
+
+    const metadata = {
+      name: 'Test Song',
+      artist: 'Test Artist',
+      charter: 'Test Charter',
+      is_valid: true // should become "True"
+    }
+
+    const sngOutPath = join(testDir, 'test_song.sng')
+
+    // Run packSng
+    await packSng(songDir, metadata, sngOutPath)
+
+    expect(existsSync(sngOutPath)).toBe(true)
+
+    // Decode and verify SNG file
+    const fileBuf = await readFile(sngOutPath)
+
+    // Header
+    const magic = fileBuf.subarray(0, 6).toString('ascii')
+    expect(magic).toBe('SNGPKG')
+
+    const version = fileBuf.readUInt32LE(6)
+    expect(version).toBe(1)
+
+    const seed = fileBuf.subarray(10, 26)
+    expect(seed.length).toBe(16)
+
+    // Helper: generate keystream
+    const keystream = Buffer.alloc(256)
+    for (let i = 0; i < 256; i++) {
+      keystream[i] = seed[i % 16] ^ i
+    }
+
+    let cursor = 26
+
+    // Metadata Section
+    const metadataSecLen = fileBuf.readBigUInt64LE(cursor)
+    cursor += 8
+
+    const count = fileBuf.readBigUInt64LE(cursor)
+    expect(count).toBe(4n) // name, artist, charter, is_valid
+    
+    const parsedMetadata: Record<string, string> = {}
+    let metaOffset = cursor + 8
+    for (let i = 0; i < Number(count); i++) {
+      const keyLen = fileBuf.readInt32LE(metaOffset)
+      metaOffset += 4
+      const key = fileBuf.subarray(metaOffset, metaOffset + keyLen).toString('utf-8')
+      metaOffset += keyLen
+
+      const valLen = fileBuf.readInt32LE(metaOffset)
+      metaOffset += 4
+      const val = fileBuf.subarray(metaOffset, metaOffset + valLen).toString('utf-8')
+      metaOffset += valLen
+
+      parsedMetadata[key] = val
+    }
+    expect(parsedMetadata.name).toBe('Test Song')
+    expect(parsedMetadata.artist).toBe('Test Artist')
+    expect(parsedMetadata.charter).toBe('Test Charter')
+    expect(parsedMetadata.is_valid).toBe('True')
+
+    cursor += Number(metadataSecLen)
+
+    // File Index Section
+    const fileIndexSecLen = fileBuf.readBigUInt64LE(cursor)
+    cursor += 8
+
+    const fileCount = fileBuf.readBigUInt64LE(cursor)
+    expect(fileCount).toBe(2n) // notes.chart, guitar.ogg (song.ini & desktop.ini are ignored)
+
+    const indexEntries: Array<{ name: string; size: bigint; offset: bigint }> = []
+    let idxOffset = cursor + 8
+    for (let i = 0; i < Number(fileCount); i++) {
+      const nameLen = fileBuf.readUInt8(idxOffset)
+      idxOffset += 1
+      const name = fileBuf.subarray(idxOffset, idxOffset + nameLen).toString('utf-8')
+      idxOffset += nameLen
+
+      const size = fileBuf.readBigUInt64LE(idxOffset)
+      idxOffset += 8
+      const offset = fileBuf.readBigUInt64LE(idxOffset)
+      idxOffset += 8
+
+      indexEntries.push({ name, size, offset })
+    }
+
+    expect(indexEntries.map(e => e.name)).toContain('notes.chart')
+    expect(indexEntries.map(e => e.name)).toContain('guitar.ogg')
+
+    cursor += Number(fileIndexSecLen)
+
+    // File Data Section
+    const fileDataSecLen = fileBuf.readBigUInt64LE(cursor)
+    cursor += 8
+
+    const payloadBlock = fileBuf.subarray(cursor)
+    expect(BigInt(payloadBlock.length)).toBe(fileDataSecLen)
+
+    // Decrypt and verify files using relative offsets (keystream starts at 0 for each file)
+    for (const file of indexEntries) {
+      const start = Number(file.offset)
+      const end = start + Number(file.size)
+      const encryptedData = fileBuf.subarray(start, end)
+      
+      const decryptedData = Buffer.from(encryptedData)
+      for (let i = 0; i < decryptedData.length; i++) {
+        decryptedData[i] ^= keystream[i % 256]
+      }
+
+      if (file.name === 'notes.chart') {
+        expect(decryptedData.toString('utf-8')).toBe('[Song]\n{\n  Resolution = 192\n}\n')
+      } else if (file.name === 'guitar.ogg') {
+        expect(decryptedData.toString('utf-8')).toBe('OGG MOCK DATA')
+      }
+    }
+  })
+
+  it('throws an error if the song directory does not exist', async () => {
+    const nonExistent = join(testDir, 'non_existent_folder_abc')
+    const sngOutPath = join(testDir, 'should_fail.sng')
+    await expect(packSng(nonExistent, {}, sngOutPath)).rejects.toThrow()
+  })
+
+  it('throws an error if the song folder contains no playable files (no notes.chart or notes.mid)', async () => {
+    const badSongDir = join(testDir, 'bad_song_no_chart')
+    await mkdir(badSongDir, { recursive: true })
+    await writeFile(join(badSongDir, 'guitar.ogg'), 'OGG MOCK DATA')
+    
+    const sngOutPath = join(testDir, 'should_fail.sng')
+    await expect(packSng(badSongDir, {}, sngOutPath)).rejects.toThrow('Song directory does not contain a notes.chart or notes.mid file.')
+  })
+
+  it('throws an error if a filename in the folder exceeds 255 bytes', async () => {
+    const badSongDir = join(testDir, 'bad_song_long_name')
+    await mkdir(badSongDir, { recursive: true })
+    await writeFile(join(badSongDir, 'notes.chart'), 'MOCK CHART')
+    
+    const sngOutPath = join(testDir, 'should_fail.sng')
+    await expect(packSng(badSongDir, {}, sngOutPath)).rejects.toThrow('Filename is too long for SNG format')
+  })
+})

--- a/src/main/sngPacker.ts
+++ b/src/main/sngPacker.ts
@@ -198,6 +198,11 @@ export async function packSng(
   // 7. Write atomically using temporary file and write stream
   const tempPath = `${outputPath}.tmp`
   const writeStream = createWriteStream(tempPath)
+  let writeError: Error | null = null
+  const onStreamError = (err: Error): void => {
+    writeError = err
+  }
+  writeStream.on('error', onStreamError)
 
   try {
     // Write headers
@@ -208,8 +213,13 @@ export async function packSng(
 
     // Write file payloads sequentially (streaming style, low RAM profile)
     for (const entry of fileEntries) {
+      if (writeError) throw writeError
+
       const filePath = join(songDir, entry.name)
       const rawData = await readFile(filePath)
+      if (rawData.length !== entry.size) {
+        throw new Error(`File changed size during export: ${entry.name}`)
+      }
       
       // Encrypt rawData with keystream relative to each file's start (0-indexed)
       const encrypted = Buffer.from(rawData)
@@ -217,21 +227,47 @@ export async function packSng(
         encrypted[i] ^= keystream[i % 256]
       }
 
+      if (writeError) throw writeError
+
       const canWrite = writeStream.write(encrypted)
       if (!canWrite) {
-        // Wait for drain event if kernel buffers are full
-        await new Promise<void>((resolve) => {
-          writeStream.once('drain', resolve)
+        // Wait for drain event or stream error
+        await new Promise<void>((resolve, reject) => {
+          if (writeError) {
+            reject(writeError)
+            return
+          }
+          const onDrain = (): void => {
+            writeStream.off('error', onError)
+            resolve()
+          }
+          const onError = (err: Error): void => {
+            writeStream.off('drain', onDrain)
+            reject(err)
+          }
+          writeStream.once('drain', onDrain)
+          writeStream.once('error', onError)
         })
       }
     }
 
     // Wait for the stream to finish writing
     await new Promise<void>((resolve, reject) => {
-      writeStream.end(() => {
+      if (writeError) {
+        reject(writeError)
+        return
+      }
+      const onFinish = (): void => {
+        writeStream.off('error', onError)
         resolve()
-      })
-      writeStream.on('error', reject)
+      }
+      const onError = (err: Error): void => {
+        writeStream.off('finish', onFinish)
+        reject(err)
+      }
+      writeStream.once('finish', onFinish)
+      writeStream.once('error', onError)
+      writeStream.end()
     })
 
     // Rename temp file to output path (atomic swap)
@@ -247,5 +283,7 @@ export async function packSng(
       // Ignore cleanup error
     }
     throw err
+  } finally {
+    writeStream.off('error', onStreamError)
   }
 }

--- a/src/main/sngPacker.ts
+++ b/src/main/sngPacker.ts
@@ -1,0 +1,251 @@
+import { readdir, readFile, rename, unlink } from 'fs/promises'
+import { join } from 'path'
+import { existsSync, statSync, createWriteStream } from 'fs'
+import { randomBytes } from 'crypto'
+
+interface SngMetadata {
+  [key: string]: string | number | boolean
+}
+
+// Generate the 256-byte keystream from a 16-byte seed
+function generateKeystream(seed: Buffer): Buffer {
+  const keystream = Buffer.alloc(256)
+  for (let i = 0; i < 256; i++) {
+    keystream[i] = seed[i % 16] ^ i
+  }
+  return keystream
+}
+
+/**
+ * Packages all files in a song folder (except song.ini, desktop.ini, .bak files, etc.)
+ * into a single Clone Hero .sng file.
+ */
+export async function packSng(
+  songDir: string,
+  metadata: SngMetadata,
+  outputPath: string
+): Promise<void> {
+  if (!existsSync(songDir)) {
+    throw new Error(`Song directory does not exist: ${songDir}`)
+  }
+
+  // 1. Gather all files to include and determine their sizes
+  const allEntries = await readdir(songDir)
+  const filesList: Array<{ name: string; size: number }> = []
+
+  for (const entry of allEntries) {
+    const entryPath = join(songDir, entry)
+    const lowerEntry = entry.toLowerCase()
+    
+    // Ignore song.ini (metadata section contains its info), system files, backups/temp files,
+    // and directories.
+    if (
+      lowerEntry === 'song.ini' ||
+      lowerEntry === 'desktop.ini' ||
+      lowerEntry === '.ds_store' ||
+      lowerEntry === 'video.json' ||
+      lowerEntry === 'audio.json' ||
+      lowerEntry === 'venue.json' ||
+      lowerEntry.endsWith('.bak1') ||
+      lowerEntry.endsWith('.bak2') ||
+      lowerEntry.endsWith('.bak3') ||
+      lowerEntry.endsWith('.tmp')
+    ) {
+      continue
+    }
+
+    try {
+      const stat = statSync(entryPath)
+      if (stat.isFile()) {
+        filesList.push({ name: entry, size: stat.size })
+      }
+    } catch {
+      // Ignore unreachable files
+    }
+  }
+
+  // Validation: Check that the folder isn't empty of playable files
+  if (filesList.length === 0) {
+    throw new Error('Song directory contains no packable files.')
+  }
+
+  const hasChartOrMidi = filesList.some((f) => {
+    const lower = f.name.toLowerCase()
+    return lower === 'notes.chart' || lower === 'notes.mid'
+  })
+  if (!hasChartOrMidi) {
+    throw new Error('Song directory does not contain a notes.chart or notes.mid file.')
+  }
+
+  // 2. Generate random 16-byte seed and repeating keystream
+  const seed = randomBytes(16)
+  const keystream = generateKeystream(seed)
+
+  // 3. Build Metadata Section Data Buffer
+  // Format: count (uint64LE) + key/value pairs
+  // Each pair: keyLength (int32LE) + key (UTF-8) + valueLength (int32LE) + value (UTF-8)
+  const metaPairs: Array<{ keyBuf: Buffer; valBuf: Buffer }> = []
+  for (const [key, value] of Object.entries(metadata)) {
+    // Normalization rules:
+    // - Clone Hero will error if a metadata value is completely empty. Empty values must be pruned.
+    // - Boolean values must be normalized to capitalized strings ("True" or "False").
+    let valStr = ''
+    if (value === undefined || value === null) {
+      continue
+    } else if (typeof value === 'boolean') {
+      valStr = value ? 'True' : 'False'
+    } else {
+      valStr = String(value).trim()
+      const lowerKey = key.toLowerCase()
+      const rawKeys = ['name', 'artist', 'album', 'genre', 'sub_genre', 'year', 'charter', 'frets']
+      if (!rawKeys.includes(lowerKey)) {
+        const lowerVal = valStr.toLowerCase()
+        if (lowerVal === 'true') {
+          valStr = 'True'
+        } else if (lowerVal === 'false') {
+          valStr = 'False'
+        }
+      }
+    }
+
+    if (valStr === '') {
+      continue
+    }
+
+    const keyBuf = Buffer.from(key, 'utf-8')
+    const valBuf = Buffer.from(valStr, 'utf-8')
+    metaPairs.push({ keyBuf, valBuf })
+  }
+
+  // Calculate Metadata Section Length
+  let metaDataSize = 8 // for count (uint64LE)
+  for (const pair of metaPairs) {
+    metaDataSize += 4 + pair.keyBuf.length + 4 + pair.valBuf.length
+  }
+
+  const metaBuffer = Buffer.alloc(8 + metaDataSize) // 8 bytes for metadataSectionLength field + metaDataSize
+  metaBuffer.writeBigUInt64LE(BigInt(metaDataSize), 0)
+  metaBuffer.writeBigUInt64LE(BigInt(metaPairs.length), 8)
+
+  let metaOffset = 16
+  for (const pair of metaPairs) {
+    metaBuffer.writeInt32LE(pair.keyBuf.length, metaOffset)
+    metaOffset += 4
+    pair.keyBuf.copy(metaBuffer, metaOffset)
+    metaOffset += pair.keyBuf.length
+
+    metaBuffer.writeInt32LE(pair.valBuf.length, metaOffset)
+    metaOffset += 4
+    pair.valBuf.copy(metaBuffer, metaOffset)
+    metaOffset += pair.valBuf.length
+  }
+
+  // 4. Calculate File Index Section Length (to determine absolute offsets)
+  let indexDataSize = 8 // count (uint64LE)
+  for (const file of filesList) {
+    const nameBuf = Buffer.from(file.name, 'utf-8')
+    if (nameBuf.length > 255) {
+      throw new Error(`Filename is too long for SNG format: ${file.name}`)
+    }
+    indexDataSize += 1 + nameBuf.length + 8 + 8
+  }
+
+  // Calculate the absolute offset where the payload block starts
+  const absoluteHeaderSize = 26 + (8 + metaDataSize) + (8 + indexDataSize) + 8
+
+  // Build file index entries with their exact absolute offsets
+  const fileEntries: Array<{ name: string; size: number; offset: number }> = []
+  let currentOffset = absoluteHeaderSize
+
+  for (const file of filesList) {
+    fileEntries.push({
+      name: file.name,
+      size: file.size,
+      offset: currentOffset
+    })
+    currentOffset += file.size
+  }
+
+  // Build File Index Buffer
+  const indexBuffer = Buffer.alloc(8 + indexDataSize)
+  indexBuffer.writeBigUInt64LE(BigInt(indexDataSize), 0)
+  indexBuffer.writeBigUInt64LE(BigInt(fileEntries.length), 8)
+
+  let indexOffset = 16
+  for (const entry of fileEntries) {
+    const nameBuf = Buffer.from(entry.name, 'utf-8')
+    indexBuffer.writeUInt8(nameBuf.length, indexOffset)
+    indexOffset += 1
+    nameBuf.copy(indexBuffer, indexOffset)
+    indexOffset += nameBuf.length
+    indexBuffer.writeBigUInt64LE(BigInt(entry.size), indexOffset)
+    indexOffset += 8
+    indexBuffer.writeBigUInt64LE(BigInt(entry.offset), indexOffset)
+    indexOffset += 8
+  }
+
+  // 5. Build File Data Header Buffer
+  const payloadDataSize = currentOffset - absoluteHeaderSize
+  const payloadHeaderBuffer = Buffer.alloc(8)
+  payloadHeaderBuffer.writeBigUInt64LE(BigInt(payloadDataSize), 0)
+
+  // 6. Build the header:
+  const headerBuffer = Buffer.alloc(26)
+  headerBuffer.write('SNGPKG', 0, 'ascii')
+  headerBuffer.writeUInt32LE(1, 6)
+  seed.copy(headerBuffer, 10)
+
+  // 7. Write atomically using temporary file and write stream
+  const tempPath = `${outputPath}.tmp`
+  const writeStream = createWriteStream(tempPath)
+
+  try {
+    // Write headers
+    writeStream.write(headerBuffer)
+    writeStream.write(metaBuffer)
+    writeStream.write(indexBuffer)
+    writeStream.write(payloadHeaderBuffer)
+
+    // Write file payloads sequentially (streaming style, low RAM profile)
+    for (const entry of fileEntries) {
+      const filePath = join(songDir, entry.name)
+      const rawData = await readFile(filePath)
+      
+      // Encrypt rawData with keystream relative to each file's start (0-indexed)
+      const encrypted = Buffer.from(rawData)
+      for (let i = 0; i < rawData.length; i++) {
+        encrypted[i] ^= keystream[i % 256]
+      }
+
+      const canWrite = writeStream.write(encrypted)
+      if (!canWrite) {
+        // Wait for drain event if kernel buffers are full
+        await new Promise<void>((resolve) => {
+          writeStream.once('drain', resolve)
+        })
+      }
+    }
+
+    // Wait for the stream to finish writing
+    await new Promise<void>((resolve, reject) => {
+      writeStream.end(() => {
+        resolve()
+      })
+      writeStream.on('error', reject)
+    })
+
+    // Rename temp file to output path (atomic swap)
+    await rename(tempPath, outputPath)
+  } catch (err) {
+    // Cleanup temporary file in case of error
+    writeStream.destroy()
+    try {
+      if (existsSync(tempPath)) {
+        await unlink(tempPath)
+      }
+    } catch {
+      // Ignore cleanup error
+    }
+    throw err
+  }
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -29,6 +29,7 @@ interface ChartEditorAPI {
     metadata: Record<string, unknown>,
     outputPath: string
   ) => Promise<{ success: boolean; error?: string }>
+  fileExists: (filePath: string) => Promise<boolean>
 
   // Album art APIs
   readAlbumArt: (songPath: string) => Promise<string | null>

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -12,6 +12,7 @@ interface ChartEditorAPI {
   openAudioFilesDialog: () => Promise<string[]>
   openAudioFolderDialog: () => Promise<string | null>
   openOutputFolderDialog: () => Promise<string | null>
+  showItemInFolder: (filePath: string) => Promise<boolean>
   getDefaultAutoChartOutputDir: () => Promise<string>
   openLyricsFileDialog: () => Promise<{ filePath: string; content: string } | null>
 
@@ -23,6 +24,11 @@ interface ChartEditorAPI {
   readSongMidi: (songPath: string) => Promise<{ type: 'midi' | 'chart'; data: string } | null>
   writeSongMidi: (songPath: string, midiBase64: string) => Promise<boolean>
   writeSongChart: (songPath: string, chartText: string) => Promise<boolean>
+  exportSng: (
+    songPath: string,
+    metadata: Record<string, unknown>,
+    outputPath: string
+  ) => Promise<{ success: boolean; error?: string }>
 
   // Album art APIs
   readAlbumArt: (songPath: string) => Promise<string | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -23,6 +23,9 @@ const api = {
   openOutputFolderDialog: (): Promise<string | null> =>
     ipcRenderer.invoke('dialog:openOutputFolder'),
 
+  showItemInFolder: (filePath: string): Promise<boolean> =>
+    ipcRenderer.invoke('dialog:showItemInFolder', filePath),
+
   getDefaultAutoChartOutputDir: (): Promise<string> =>
     ipcRenderer.invoke('strum:getDefaultOutputFolder'),
 
@@ -53,6 +56,13 @@ const api = {
 
   writeSongChart: (songPath: string, chartText: string): Promise<boolean> =>
     ipcRenderer.invoke('song:writeChart', songPath, chartText),
+
+  exportSng: (
+    songPath: string,
+    metadata: Record<string, unknown>,
+    outputPath: string
+  ): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('song:exportSng', songPath, metadata, outputPath),
 
   // Album art APIs
   readAlbumArt: (songPath: string): Promise<string | null> =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -64,6 +64,9 @@ const api = {
   ): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('song:exportSng', songPath, metadata, outputPath),
 
+  fileExists: (filePath: string): Promise<boolean> =>
+    ipcRenderer.invoke('fs:fileExists', filePath),
+
   // Album art APIs
   readAlbumArt: (songPath: string): Promise<string | null> =>
     ipcRenderer.invoke('song:readAlbumArt', songPath),

--- a/src/renderer/src/components/ExportModal.css
+++ b/src/renderer/src/components/ExportModal.css
@@ -232,7 +232,8 @@
   font-size: 13px;
   line-height: 1.5;
   color: var(--text-secondary);
-  max-width: 420px;
+  max-width: 520px;
+  text-wrap: pretty;
 }
 
 .export-path-preview {

--- a/src/renderer/src/components/ExportModal.css
+++ b/src/renderer/src/components/ExportModal.css
@@ -410,3 +410,34 @@
   accent-color: var(--accent-color);
   cursor: pointer;
 }
+
+.export-warning-banner {
+  display: flex;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.22);
+  color: var(--text-primary);
+  margin-top: 10px;
+  animation: fadeIn 0.15s ease-out;
+}
+
+.warning-icon {
+  font-size: 18px;
+  align-self: flex-start;
+}
+
+.warning-text strong {
+  display: block;
+  font-size: 12px;
+  margin-bottom: 2px;
+  color: #f59e0b; /* Amber */
+}
+
+.warning-text p {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}

--- a/src/renderer/src/components/ExportModal.css
+++ b/src/renderer/src/components/ExportModal.css
@@ -1,11 +1,104 @@
+.export-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: rgba(0, 0, 0, 0.62);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
 .export-modal {
   width: min(640px, 100%);
   max-height: min(90vh, 700px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  box-shadow: var(--shadow-lg);
   position: relative;
+}
+
+.export-modal-header,
+.export-modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.export-modal-footer {
+  border-bottom: none;
+  border-top: 1px solid var(--border-color);
+  justify-content: flex-end;
+}
+
+.export-modal-title {
+  margin: 0;
+  font-size: 20px;
+  color: var(--text-primary);
+}
+
+.export-modal-subtitle {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.export-modal-close,
+.export-modal-primary,
+.export-modal-secondary {
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  transition: all 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.export-modal-close {
+  width: 34px;
+  height: 34px;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 0;
+}
+
+.export-modal-primary {
+  background: var(--accent-color);
+  color: #1f1a13;
+  border-color: rgba(0, 0, 0, 0.18);
+}
+
+.export-modal-primary:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.export-modal-close:hover,
+.export-modal-secondary:hover {
+  background: var(--bg-secondary);
+  border-color: var(--text-secondary);
+}
+
+.export-modal-primary:hover:not(:disabled) {
+  opacity: 0.9;
 }
 
 .export-modal-body {
   padding: 24px;
+  overflow-y: auto;
 }
 
 .export-section {

--- a/src/renderer/src/components/ExportModal.css
+++ b/src/renderer/src/components/ExportModal.css
@@ -1,0 +1,319 @@
+.export-modal {
+  width: min(640px, 100%);
+  max-height: min(90vh, 700px);
+  position: relative;
+}
+
+.export-modal-body {
+  padding: 24px;
+}
+
+.export-section {
+  margin-bottom: 24px;
+}
+
+.export-section:last-of-type {
+  margin-bottom: 0;
+}
+
+.export-section-title {
+  margin: 0 0 12px 0;
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+}
+
+.export-formats-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+.export-format-card {
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background: rgba(255, 255, 255, 0.01);
+  transition: all 0.2s ease;
+  cursor: pointer;
+  position: relative;
+}
+
+.export-format-card.active {
+  border-color: #3b82f6; /* Accent color */
+  background: rgba(59, 130, 246, 0.05);
+  box-shadow: 0 0 12px rgba(59, 130, 246, 0.15);
+}
+
+.export-format-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.export-format-badge {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 99px;
+  background: #3b82f6;
+  color: #ffffff;
+}
+
+.export-format-icon {
+  font-size: 20px;
+}
+
+.export-format-card h4 {
+  margin: 0 0 6px 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.export-format-card p {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.export-error-banner {
+  display: flex;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  color: var(--text-primary);
+  margin-bottom: 20px;
+}
+
+.error-icon {
+  font-size: 20px;
+  align-self: flex-start;
+}
+
+.error-text strong {
+  display: block;
+  font-size: 13px;
+  margin-bottom: 2px;
+  color: #ef4444;
+}
+
+.error-text p {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+/* Success View */
+.export-status-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 30px 20px;
+}
+
+.export-status-icon {
+  font-size: 48px;
+  margin-bottom: 16px;
+  animation: scaleIn 0.3s ease-out;
+}
+
+.export-status-container h3 {
+  margin: 0 0 8px 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.export-success-message {
+  margin: 0 0 24px 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  max-width: 420px;
+}
+
+.export-path-preview {
+  width: 100%;
+  padding: 16px;
+  border-radius: 8px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  text-align: left;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.export-path-code-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.export-path-preview strong {
+  display: block;
+  font-size: 11px;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.export-path-preview code {
+  display: block;
+  font-family: monospace;
+  font-size: 12px;
+  word-break: break-all;
+  white-space: pre-wrap;
+  color: #10b981; /* Green tone for path */
+}
+
+.reveal-folder-button {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  padding: 6px 12px;
+  height: auto;
+  border-radius: 6px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+/* Folder Input Label Layout */
+.export-folder-label-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.export-folder-label-row .settings-field-label {
+  margin-bottom: 0;
+}
+
+.export-reset-button {
+  background: none;
+  border: none;
+  font-size: 11px;
+  font-weight: 500;
+  color: #3b82f6;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.15s ease;
+  text-decoration: underline;
+}
+
+.export-reset-button:hover {
+  color: #60a5fa;
+}
+
+.export-reset-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Loading Overlay */
+.export-loading-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.7);
+  backdrop-filter: blur(4px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  z-index: 10;
+  animation: fadeIn 0.2s ease;
+}
+
+.export-loading-spinner {
+  width: 36px;
+  height: 36px;
+  border: 3px solid rgba(255, 255, 255, 0.1);
+  border-radius: 50%;
+  border-top-color: #3b82f6;
+  animation: spin 1s linear infinite;
+}
+
+.export-loading-overlay p {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes scaleIn {
+  from { transform: scale(0.8); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Base Modal Layout Structure (scoped to export) */
+.export-preferences-body {
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+}
+
+.export-field-stack {
+  display: grid;
+  gap: 8px;
+}
+
+.export-field-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.export-folder-picker {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+}
+
+.export-folder-input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  box-sizing: border-box;
+}
+
+.export-checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.export-checkbox-row input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent-color);
+  cursor: pointer;
+}

--- a/src/renderer/src/components/ExportModal.css
+++ b/src/renderer/src/components/ExportModal.css
@@ -135,9 +135,9 @@
 }
 
 .export-format-card.active {
-  border-color: #3b82f6; /* Accent color */
-  background: rgba(59, 130, 246, 0.05);
-  box-shadow: 0 0 12px rgba(59, 130, 246, 0.15);
+  border-color: var(--accent-color);
+  background: var(--accent-color-transparent);
+  box-shadow: 0 0 12px var(--accent-color-transparent);
 }
 
 .export-format-card-header {
@@ -153,8 +153,8 @@
   text-transform: uppercase;
   padding: 2px 8px;
   border-radius: 99px;
-  background: #3b82f6;
-  color: #ffffff;
+  background: var(--accent-color);
+  color: #1f1a13;
 }
 
 .export-format-icon {
@@ -180,8 +180,8 @@
   gap: 12px;
   padding: 12px 16px;
   border-radius: 8px;
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.25);
+  background: rgba(240, 109, 109, 0.1);
+  border: 1px solid rgba(240, 109, 109, 0.25);
   color: var(--text-primary);
   margin-bottom: 20px;
 }
@@ -195,7 +195,7 @@
   display: block;
   font-size: 13px;
   margin-bottom: 2px;
-  color: #ef4444;
+  color: var(--danger-color);
 }
 
 .error-text p {
@@ -267,7 +267,7 @@
   font-size: 12px;
   word-break: break-all;
   white-space: pre-wrap;
-  color: #10b981; /* Green tone for path */
+  color: var(--success-color);
 }
 
 .reveal-folder-button {
@@ -301,7 +301,7 @@
   border: none;
   font-size: 11px;
   font-weight: 500;
-  color: #3b82f6;
+  color: var(--accent-color);
   cursor: pointer;
   padding: 0;
   transition: color 0.15s ease;
@@ -309,7 +309,7 @@
 }
 
 .export-reset-button:hover {
-  color: #60a5fa;
+  color: var(--accent-color-hover);
 }
 
 .export-reset-button:disabled {
@@ -337,7 +337,7 @@
   height: 36px;
   border: 3px solid rgba(255, 255, 255, 0.1);
   border-radius: 50%;
-  border-top-color: #3b82f6;
+  border-top-color: var(--accent-color);
   animation: spin 1s linear infinite;
 }
 
@@ -416,8 +416,8 @@
   gap: 12px;
   padding: 10px 14px;
   border-radius: 8px;
-  background: rgba(245, 158, 11, 0.08);
-  border: 1px solid rgba(245, 158, 11, 0.22);
+  background: rgba(242, 166, 90, 0.08);
+  border: 1px solid rgba(242, 166, 90, 0.22);
   color: var(--text-primary);
   margin-top: 10px;
   animation: fadeIn 0.15s ease-out;
@@ -432,7 +432,7 @@
   display: block;
   font-size: 12px;
   margin-bottom: 2px;
-  color: #f59e0b; /* Amber */
+  color: var(--warning-color);
 }
 
 .warning-text p {

--- a/src/renderer/src/components/ExportModal.tsx
+++ b/src/renderer/src/components/ExportModal.tsx
@@ -1,0 +1,291 @@
+import { useEffect, useState } from 'react'
+import { useSettingsStore, useUIStore, useProjectStore, getSongStore } from '../stores'
+import './ExportModal.css'
+
+interface ExportModalProps {
+  onSaveBeforeExport: () => Promise<void>
+}
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[\\/:*?"<>|]/g, '_').trim()
+}
+
+export function ExportModal({ onSaveBeforeExport }: ExportModalProps): React.JSX.Element | null {
+  const isOpen = useUIStore((s) => s.isExportModalOpen)
+  const setExportModalOpen = useUIStore((s) => s.setExportModalOpen)
+  
+  const activeSongId = useProjectStore((s) => s.activeSongId)
+  const autoChartOutputDir = useSettingsStore((s) => s.autoChartOutputDir)
+  const sngLastExportDir = useSettingsStore((s) => s.sngLastExportDir)
+  const updateSettings = useSettingsStore((s) => s.updateSettings)
+
+  const [outputFolder, setOutputFolder] = useState<string>('')
+  const [filename, setFilename] = useState<string>('')
+  const [saveBeforeExport, setSaveBeforeExport] = useState<boolean>(true)
+  
+  const [status, setStatus] = useState<'idle' | 'saving' | 'exporting' | 'success' | 'error'>('idle')
+  const [errorMessage, setErrorMessage] = useState<string>('')
+  const [exportedPath, setExportedPath] = useState<string>('')
+
+  // Get current song data
+  const songStore = activeSongId ? getSongStore(activeSongId) : null
+  const song = songStore ? songStore.getState().song : null
+
+  const showReset = outputFolder !== (autoChartOutputDir || '')
+
+  // Initialize output folder and filename when the modal is opened
+  useEffect(() => {
+    if (isOpen && song) {
+      setOutputFolder(sngLastExportDir || autoChartOutputDir || '')
+      const name = song.metadata.name || 'song'
+      setFilename(`${sanitizeFilename(name)}.sng`)
+      setStatus('idle')
+      setErrorMessage('')
+      setExportedPath('')
+    }
+  }, [isOpen, song, autoChartOutputDir, sngLastExportDir])
+
+  // Dismiss modal on Escape key press
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && status !== 'saving' && status !== 'exporting') {
+        setExportModalOpen(false)
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, status, setExportModalOpen])
+
+  if (!isOpen || !song) return null
+
+  const handleBrowse = async () => {
+    try {
+      const path = await window.api.openOutputFolderDialog()
+      if (path) {
+        setOutputFolder(path)
+      }
+    } catch (err) {
+      console.error('Failed to open output folder dialog:', err)
+    }
+  }
+
+  const handleExport = async () => {
+    if (!outputFolder.trim()) {
+      setErrorMessage('Please select a destination output folder.')
+      setStatus('error')
+      return
+    }
+
+    let finalFilename = filename.trim()
+    if (!finalFilename) {
+      finalFilename = `${sanitizeFilename(song.metadata.name || 'song')}.sng`
+    } else if (!finalFilename.toLowerCase().endsWith('.sng')) {
+      finalFilename += '.sng'
+    }
+
+    setStatus('saving')
+    setErrorMessage('')
+
+    try {
+      // 1. Optionally save the song first (so disk files are up to date)
+      if (saveBeforeExport) {
+        await onSaveBeforeExport()
+      }
+
+      // 2. Perform the export
+      setStatus('exporting')
+      
+      const separator = outputFolder.includes('\\') ? '\\' : '/'
+      const fullOutputPath = outputFolder.endsWith(separator) 
+        ? `${outputFolder}${finalFilename}` 
+        : `${outputFolder}${separator}${finalFilename}`
+
+      const result = await window.api.exportSng(
+        song.folderPath,
+        song.metadata as Record<string, unknown>,
+        fullOutputPath
+      )
+
+      if (result.success) {
+        setExportedPath(fullOutputPath)
+        updateSettings({ sngLastExportDir: outputFolder })
+        setStatus('success')
+      } else {
+        setErrorMessage(result.error || 'Failed to export the song package.')
+        setStatus('error')
+      }
+    } catch (err) {
+      console.error('Export error:', err)
+      setErrorMessage(err instanceof Error ? err.message : String(err))
+      setStatus('error')
+    }
+  }
+
+  return (
+    <div className="export-modal-overlay" onClick={() => status !== 'saving' && status !== 'exporting' && setExportModalOpen(false)}>
+      <div className="export-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="export-modal-header">
+          <div>
+            <h2 className="export-modal-title">Export Song Package</h2>
+            <p className="export-modal-subtitle">Package and build your song for rhythm games.</p>
+          </div>
+          <button 
+            className="export-modal-close" 
+            onClick={() => setExportModalOpen(false)}
+            disabled={status === 'saving' || status === 'exporting'}
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="export-modal-body">
+          {status === 'success' ? (
+            <div className="export-status-container success">
+              <span className="export-status-icon">✅</span>
+              <h3>Export Successful!</h3>
+              <p className="export-success-message">Your song has been successfully packaged into a single Clone Hero .sng file.</p>
+              <div className="export-path-preview">
+                <div className="export-path-code-container">
+                  <strong>Destination:</strong>
+                  <code>{exportedPath}</code>
+                </div>
+                <button
+                  className="export-modal-secondary reveal-folder-button"
+                  onClick={() => window.api.showItemInFolder(exportedPath)}
+                >
+                  📁 Show in Folder
+                </button>
+              </div>
+            </div>
+          ) : (
+            <>
+              {status === 'error' && (
+                <div className="export-error-banner">
+                  <span className="error-icon">⚠️</span>
+                  <div className="error-text">
+                    <strong>Export Failed</strong>
+                    <p>{errorMessage}</p>
+                  </div>
+                </div>
+              )}
+
+              {/* Formats Section */}
+              <div className="export-section">
+                <h3 className="export-section-title">Format Option</h3>
+                <div className="export-formats-grid">
+                  <div className="export-format-card active">
+                    <div className="export-format-card-header">
+                      <span className="export-format-badge">Active</span>
+                      <span className="export-format-icon">🎸</span>
+                    </div>
+                    <h4>Clone Hero (.sng)</h4>
+                    <p>Standard encrypted archive packaging notes, audio stems, and art into a single file container.</p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Destination Section */}
+              <div className="export-section">
+                <h3 className="export-section-title">Destination & Naming</h3>
+                
+                <div className="export-preferences-body" style={{ padding: 0 }}>
+                  {/* Output Folder Picker */}
+                  <div className="export-field-stack">
+                    <div className="export-folder-label-row">
+                      <label className="export-field-label">Output Folder</label>
+                      {showReset && (
+                        <button
+                          className="export-reset-button"
+                          onClick={() => setOutputFolder(autoChartOutputDir || '')}
+                          disabled={status === 'saving' || status === 'exporting'}
+                        >
+                          Reset to Default
+                        </button>
+                      )}
+                    </div>
+                    <div className="export-folder-picker">
+                      <input
+                        className="export-folder-input"
+                        type="text"
+                        value={outputFolder}
+                        placeholder="Click browse to choose an export directory..."
+                        onChange={(e) => setOutputFolder(e.target.value)}
+                        disabled={status === 'saving' || status === 'exporting'}
+                      />
+                      <button
+                        className="export-modal-secondary"
+                        onClick={handleBrowse}
+                        disabled={status === 'saving' || status === 'exporting'}
+                      >
+                        Browse
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* Filename Input */}
+                  <div className="export-field-stack" style={{ marginTop: '12px' }}>
+                    <label className="export-field-label">File Name</label>
+                    <input
+                      className="export-folder-input"
+                      style={{ width: '100%' }}
+                      type="text"
+                      value={filename}
+                      placeholder="e.g. My_Song.sng"
+                      onChange={(e) => setFilename(e.target.value)}
+                      disabled={status === 'saving' || status === 'exporting'}
+                    />
+                  </div>
+
+                  {/* Save before export checkbox */}
+                  <label className="export-checkbox-row" style={{ marginTop: '16px' }}>
+                    <input
+                      type="checkbox"
+                      checked={saveBeforeExport}
+                      onChange={(e) => setSaveBeforeExport(e.target.checked)}
+                      disabled={status === 'saving' || status === 'exporting'}
+                    />
+                    <span>Save song edits to source directory before exporting</span>
+                  </label>
+                </div>
+              </div>
+
+              {/* Progress Overlay / State */}
+              {(status === 'saving' || status === 'exporting') && (
+                <div className="export-loading-overlay">
+                  <div className="export-loading-spinner"></div>
+                  <p>{status === 'saving' ? 'Saving song edits...' : 'Building .sng package...'}</p>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="export-modal-footer">
+          {status === 'success' ? (
+            <button className="export-modal-primary" onClick={() => setExportModalOpen(false)}>
+              Done
+            </button>
+          ) : (
+            <>
+              <button 
+                className="export-modal-secondary" 
+                onClick={() => setExportModalOpen(false)}
+                disabled={status === 'saving' || status === 'exporting'}
+              >
+                Cancel
+              </button>
+              <button 
+                className="export-modal-primary" 
+                onClick={handleExport}
+                disabled={status === 'saving' || status === 'exporting' || !outputFolder.trim()}
+              >
+                Export
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/ExportModal.tsx
+++ b/src/renderer/src/components/ExportModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useStore } from 'zustand'
 import { useSettingsStore, useUIStore, useProjectStore, getSongStore } from '../stores'
 import './ExportModal.css'
 
@@ -27,9 +28,9 @@ export function ExportModal({ onSaveBeforeExport }: ExportModalProps): React.JSX
   const [errorMessage, setErrorMessage] = useState<string>('')
   const [exportedPath, setExportedPath] = useState<string>('')
 
-  // Get current song data
-  const songStore = activeSongId ? getSongStore(activeSongId) : null
-  const song = songStore ? songStore.getState().song : null
+  // Get current song data reactively
+  const songStore = getSongStore(activeSongId || 'default')
+  const song = useStore(songStore, (s) => s.song)
 
   const showReset = outputFolder !== (autoChartOutputDir || '')
 
@@ -57,7 +58,7 @@ export function ExportModal({ onSaveBeforeExport }: ExportModalProps): React.JSX
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [isOpen, status, setExportModalOpen])
 
-  if (!isOpen || !song) return null
+  if (!isOpen || !activeSongId || !song) return null
 
   const handleBrowse = async () => {
     try {

--- a/src/renderer/src/components/ExportModal.tsx
+++ b/src/renderer/src/components/ExportModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { useStore } from 'zustand'
 import { useSettingsStore, useUIStore, useProjectStore, getSongStore } from '../stores'
 import './ExportModal.css'
@@ -28,23 +28,60 @@ export function ExportModal({ onSaveBeforeExport }: ExportModalProps): React.JSX
   const [errorMessage, setErrorMessage] = useState<string>('')
   const [exportedPath, setExportedPath] = useState<string>('')
 
+  const [isInitialized, setIsInitialized] = useState<boolean>(false)
+  const [showOverwriteWarning, setShowOverwriteWarning] = useState<boolean>(false)
+
   // Get current song data reactively
   const songStore = getSongStore(activeSongId || 'default')
   const song = useStore(songStore, (s) => s.song)
 
   const showReset = outputFolder !== (autoChartOutputDir || '')
 
+  const getFullOutputPath = useCallback((folder: string, name: string): string => {
+    if (!folder.trim()) return ''
+    let finalFilename = name.trim()
+    if (!finalFilename) {
+      finalFilename = `${sanitizeFilename(song?.metadata.name || 'song')}.sng`
+    } else if (!finalFilename.toLowerCase().endsWith('.sng')) {
+      finalFilename += '.sng'
+    }
+    const separator = folder.includes('\\') ? '\\' : '/'
+    return folder.endsWith(separator) 
+      ? `${folder}${finalFilename}` 
+      : `${folder}${separator}${finalFilename}`
+  }, [song])
+
+  const checkOverwrite = useCallback(async (folder: string, file: string) => {
+    const fullPath = getFullOutputPath(folder, file)
+    if (!fullPath) {
+      setShowOverwriteWarning(false)
+      return
+    }
+    try {
+      const exists = await window.api.fileExists(fullPath)
+      setShowOverwriteWarning(exists)
+    } catch (err) {
+      console.error('Error checking if file exists:', err)
+      setShowOverwriteWarning(false)
+    }
+  }, [getFullOutputPath])
+
   // Initialize output folder and filename when the modal is opened
   useEffect(() => {
-    if (isOpen && song) {
-      setOutputFolder(sngLastExportDir || autoChartOutputDir || '')
+    if (song && !isInitialized) {
+      const initialFolder = sngLastExportDir || autoChartOutputDir || ''
       const name = song.metadata.name || 'song'
-      setFilename(`${sanitizeFilename(name)}.sng`)
+      const initialFilename = `${sanitizeFilename(name)}.sng`
+      setOutputFolder(initialFolder)
+      setFilename(initialFilename)
+      setIsInitialized(true)
       setStatus('idle')
       setErrorMessage('')
       setExportedPath('')
+      
+      checkOverwrite(initialFolder, initialFilename)
     }
-  }, [isOpen, song, autoChartOutputDir, sngLastExportDir])
+  }, [song, isInitialized, autoChartOutputDir, sngLastExportDir, checkOverwrite])
 
   // Dismiss modal on Escape key press
   useEffect(() => {
@@ -65,6 +102,7 @@ export function ExportModal({ onSaveBeforeExport }: ExportModalProps): React.JSX
       const path = await window.api.openOutputFolderDialog()
       if (path) {
         setOutputFolder(path)
+        checkOverwrite(path, filename)
       }
     } catch (err) {
       console.error('Failed to open output folder dialog:', err)
@@ -112,6 +150,7 @@ export function ExportModal({ onSaveBeforeExport }: ExportModalProps): React.JSX
         setExportedPath(fullOutputPath)
         updateSettings({ sngLastExportDir: outputFolder })
         setStatus('success')
+        setShowOverwriteWarning(false)
       } else {
         setErrorMessage(result.error || 'Failed to export the song package.')
         setStatus('error')
@@ -198,7 +237,11 @@ export function ExportModal({ onSaveBeforeExport }: ExportModalProps): React.JSX
                       {showReset && (
                         <button
                           className="export-reset-button"
-                          onClick={() => setOutputFolder(autoChartOutputDir || '')}
+                          onClick={() => {
+                            const defaultDir = autoChartOutputDir || ''
+                            setOutputFolder(defaultDir)
+                            checkOverwrite(defaultDir, filename)
+                          }}
                           disabled={status === 'saving' || status === 'exporting'}
                         >
                           Reset to Default
@@ -212,6 +255,7 @@ export function ExportModal({ onSaveBeforeExport }: ExportModalProps): React.JSX
                         value={outputFolder}
                         placeholder="Click browse to choose an export directory..."
                         onChange={(e) => setOutputFolder(e.target.value)}
+                        onBlur={() => checkOverwrite(outputFolder, filename)}
                         disabled={status === 'saving' || status === 'exporting'}
                       />
                       <button
@@ -234,9 +278,20 @@ export function ExportModal({ onSaveBeforeExport }: ExportModalProps): React.JSX
                       value={filename}
                       placeholder="e.g. My_Song.sng"
                       onChange={(e) => setFilename(e.target.value)}
+                      onBlur={() => checkOverwrite(outputFolder, filename)}
                       disabled={status === 'saving' || status === 'exporting'}
                     />
                   </div>
+
+                  {showOverwriteWarning && (
+                    <div className="export-warning-banner">
+                      <span className="warning-icon">⚠️</span>
+                      <div className="warning-text">
+                        <strong>File Already Exists</strong>
+                        <p>Exporting will overwrite the existing file at this location.</p>
+                      </div>
+                    </div>
+                  )}
 
                   {/* Save before export checkbox */}
                   <label className="export-checkbox-row" style={{ marginTop: '16px' }}>

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -1,12 +1,13 @@
 // Top toolbar with playback controls and global actions
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { useProjectStore, useSettingsStore, getSongStore } from '../stores'
+import { useProjectStore, useSettingsStore, getSongStore, useUIStore } from '../stores'
 import * as audioService from '../services/audioService'
 import * as playbackController from '../services/playbackController'
 import { parseMidiBase64, parseChartFile, serializeMidiBase64, serializeChartFile } from '../utils/midiParser'
 import { validateChart, type ValidationIssue } from '../utils/chartValidation'
 import type { SongMetadata } from '../types'
 import { SettingsModal } from './SettingsModal'
+import { ExportModal } from './ExportModal'
 import './Toolbar.css'
 
 type AutoChartProgressState = {
@@ -38,6 +39,8 @@ const AUTO_CHART_STAGE_ORDER: Record<string, number> = {
 
 export function Toolbar(): React.JSX.Element {
   const { activeSongId, setLoadedFolder, addSong, setActiveSong } = useProjectStore()
+  const isExportModalOpen = useUIStore((s) => s.isExportModalOpen)
+  const setExportModalOpen = useUIStore((s) => s.setExportModalOpen)
   const {
     autosaveEnabled,
     highwaySpeed,
@@ -782,6 +785,15 @@ export function Toolbar(): React.JSX.Element {
         >
           <span className="toolbar-icon">💾</span>
           <span className="toolbar-label">Save</span>
+        </button>
+        <button
+          className="toolbar-button"
+          onClick={() => setExportModalOpen(true)}
+          disabled={!activeSongId}
+          title="Export"
+        >
+          <span className="toolbar-icon">📤</span>
+          <span className="toolbar-label">Export</span>
         </button>
       </div>
 
@@ -1722,6 +1734,7 @@ export function Toolbar(): React.JSX.Element {
       )}
 
       <SettingsModal />
+      {isExportModalOpen && <ExportModal onSaveBeforeExport={handleSave} />}
     </div>
   )
 }

--- a/src/renderer/src/stores/projectStore.ts
+++ b/src/renderer/src/stores/projectStore.ts
@@ -60,6 +60,7 @@ const defaultSettings: AppSettings = {
   leftyFlip: false,
   enableAutoChart: true,
   autoChartOutputDir: undefined,
+  sngLastExportDir: undefined,
   betaUpdates: false,
   hotkeys: cloneDefaultHotkeys()
 }
@@ -96,6 +97,7 @@ interface UIStore extends UIState {
   clearModifiers: () => void
   togglePreviewFullscreen: () => void
   setSettingsModalOpen: (open: boolean) => void
+  setExportModalOpen: (open: boolean) => void
   toggleVocalPitchPlayback: () => void
   toggleHighwayWaveform: () => void
 }
@@ -122,6 +124,7 @@ export const useUIStore = create<UIStore>()((set) => ({
   noteModifiers: { ...defaultModifiers },
   isPreviewFullscreen: false,
   isSettingsModalOpen: false,
+  isExportModalOpen: false,
   vocalPitchPlayback: false,
   showHighwayWaveform: false,
 
@@ -158,6 +161,7 @@ export const useUIStore = create<UIStore>()((set) => ({
   clearModifiers: () => set({ noteModifiers: { ...defaultModifiers } }),
   togglePreviewFullscreen: () => set((state) => ({ isPreviewFullscreen: !state.isPreviewFullscreen })),
   setSettingsModalOpen: (open) => set({ isSettingsModalOpen: open }),
+  setExportModalOpen: (open) => set({ isExportModalOpen: open }),
   toggleVocalPitchPlayback: () => set((state) => ({ vocalPitchPlayback: !state.vocalPitchPlayback })),
   toggleHighwayWaveform: () => set((state) => ({ showHighwayWaveform: !state.showHighwayWaveform }))
 }))

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -266,6 +266,7 @@ export interface AppSettings {
   leftyFlip: boolean // Mirror highway left-right for left-handed players
   enableAutoChart: boolean
   autoChartOutputDir?: string
+  sngLastExportDir?: string
   betaUpdates: boolean // Opt into beta/pre-release auto-updates
   hotkeys: AppHotkeys
 }
@@ -327,6 +328,7 @@ export interface UIState {
   noteModifiers: NoteModifiers
   isPreviewFullscreen: boolean
   isSettingsModalOpen: boolean
+  isExportModalOpen: boolean
   /** Sound vocal note pitches (sine tones) while the song plays (issue #10). */
   vocalPitchPlayback: boolean
   /** Show the audio waveform overlay on the 3D note highway (issue #7). */


### PR DESCRIPTION
This PR adds a new 'Export' feature to the toolbar to bundle and pack songs into Clone Hero `.sng` packages.

### Features
1. **Visual UI Controls**: Added an 'Export' button in the main toolbar that displays a dark-themed modal window to select output directories, customize output filenames, and decide whether to save edits before exporting.
2. **Settings Integration**: Remembers and persists the last output directory used (with a 'Reset to Default' shortcut button to fallback to the auto-chart output folder).
3. **Sequential Stream Packaging**: Replaces memory-heavy `Buffer.concat` with a low-RAM sequential `WriteStream`, lowering the memory footprint of multi-track stem packages.
4. **Atomic Swap File Writes**: Generates and writes package data to a temporary file (`*.sng.tmp`) first and swaps atomically to avoid package corruptions.
5. **Format Validation**: Automatically ignoring editor metadata files (`video.json`, `audio.json`, and `venue.json`) while verifying that playable chart files are present (and filenames don't exceed length limits).
6. **Reveal File in Explorer**: Success callouts include a 'Show in Folder' reveal action.
7. **Comprehensive Tests**: Includes detailed Vitest unit tests covering edge-case validations and packing offsets.

### References & Acknowledgments
The binary layout and encryption logic are built using the official [Onyx Reference Implementation](https://github.com/mtolly/onyx):
* [SNG.hs](https://github.com/mtolly/onyx/blob/master/haskell/packages/onyx-lib/src/Onyx/CloneHero/SNG.hs): Outlines the `.sng` index serialization layout, string boolean normalizations, and XOR encryption pattern.
* [Handle.hs](https://github.com/mtolly/onyx/blob/master/haskell/packages/onyx-handle/src/Onyx/Util/Handle.hs): Demonstrates that sub-handles use file-relative offsets (`shTell`), clarifying that the XOR keystream is 0-indexed relative to each file payload.
* [CloneHero.hs](https://github.com/mtolly/onyx/blob/master/haskell/packages/onyx-lib/src/Onyx/Build/CloneHero.hs): Clarified typical asset gather/ignore rules (e.g. ignoring `song.ini` in the data stream since metadata covers it).

### Testing Status
> [!IMPORTANT]
> This feature has not been extensively tested across all possible export maps and configurations. It has been verified to work successfully for packaging and importing drum tracks into Clone Hero, but other instrument mappings and advanced configurations have not yet been fully validated.

<img width="1153" height="1179" alt="image" src="https://github.com/user-attachments/assets/1769c17b-7697-4dac-9c36-a292fe48d3a2" />
<img width="1153" height="1179" alt="image" src="https://github.com/user-attachments/assets/c8ee4c22-f35e-4a24-aedb-c40e852cca27" />
