### PR TITLE
feat: add configurable waveform sources and piano roll waveform

### DIFF
--- a/src/renderer/src/components/ChartPreview.css
+++ b/src/renderer/src/components/ChartPreview.css
@@ -103,6 +103,23 @@
   color: var(--text-primary);
 }
 
+.waveform-source-select {
+  height: 28px;
+  max-width: 170px;
+  padding: 0 10px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.waveform-source-select:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
 /* Difficulty selector */
 /* Preview snap selector */
 .preview-snap-selector {

--- a/src/renderer/src/components/MidiEditor.css
+++ b/src/renderer/src/components/MidiEditor.css
@@ -64,9 +64,41 @@
   display: block;
 }
 
+.midi-waveform-strip {
+  display: flex;
+  align-items: stretch;
+  height: 36px;
+  border-bottom: 1px solid var(--border-color);
+  background: #0f1525;
+}
+
+.midi-waveform-label {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0 12px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  border-right: 1px solid var(--border-color);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.midi-waveform-canvas-wrap {
+  flex: 1;
+  min-width: 0;
+}
+
+.midi-waveform-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 .midi-snap-selector,
 .midi-instrument-selector,
-.midi-zoom-controls {
+.midi-zoom-controls,
+.midi-waveform-source {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -75,7 +107,8 @@
 }
 
 .midi-snap-selector select,
-.midi-instrument-selector select {
+.midi-instrument-selector select,
+.midi-waveform-source select {
   padding: 6px 10px;
   font-size: 12px;
   background-color: var(--bg-secondary);

--- a/src/renderer/src/components/MidiEditor.tsx
+++ b/src/renderer/src/components/MidiEditor.tsx
@@ -3,7 +3,8 @@ import { useRef, useEffect, useLayoutEffect, useState, useCallback, useMemo } fr
 import { useProjectStore, getSongStore, useSettingsStore, useUIStore } from '../stores'
 import type { Note, NoteFlags, NoteModifiers, Instrument, DrumLane, GuitarLane, Difficulty, EditingTool, StarPowerPhrase, SoloSection, LaneMarker, LaneMarkerType, VocalNote, VocalPhrase, HarmonyPart,TempoEvent } from '../types'
 import { PRO_KEYS_MIN, PRO_KEYS_MAX, SUSTAIN_THRESHOLD_MID, SUSTAIN_THRESHOLD_CHART } from '../types'
-import { playPitchPreview, stopPitchPreview, getAudioDuration, onAudioLoaded } from '../services/audioService'
+import { getAudioDuration, getAudioSources, onAudioLoaded, playPitchPreview, stopPitchPreview } from '../services/audioService'
+import { buildTickAlignedWaveformPeaks } from '../services/waveformService'
 import './MidiEditor.css'
 
 // Build note flags from UI toggle modifiers
@@ -145,6 +146,102 @@ function formatLaneLabel(lane: string): string {
   }
 
   return labels[lane] || lane
+}
+
+function PianoRollWaveformStrip({
+  songId,
+  headerWidth,
+  width,
+  currentTick,
+  scrollX,
+  zoomLevel,
+  tempoEvents,
+  sourcePath
+}: {
+  songId: string
+  headerWidth: number
+  width: number
+  currentTick: number
+  scrollX: number
+  zoomLevel: number
+  tempoEvents: TempoEvent[]
+  sourcePath?: string
+}): React.JSX.Element {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [audioVersion, setAudioVersion] = useState(0)
+
+  useEffect(() => onAudioLoaded(songId, () => setAudioVersion((v) => v + 1)), [songId])
+
+  const waveform = useMemo(() => {
+    void audioVersion
+    return buildTickAlignedWaveformPeaks({
+      songId,
+      tempoEvents,
+      rows: 2048,
+      sourcePath,
+      maxSamplesPerRow: 192
+    })
+  }, [songId, tempoEvents, sourcePath, audioVersion])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const w = Math.max(1, canvas.clientWidth)
+    const h = Math.max(1, canvas.clientHeight)
+    if (canvas.width !== w || canvas.height !== h) {
+      canvas.width = w
+      canvas.height = h
+    }
+
+    ctx.clearRect(0, 0, w, h)
+    ctx.fillStyle = '#0d1220'
+    ctx.fillRect(0, 0, w, h)
+
+    if (waveform) {
+      const midY = h / 2
+      const { peaks, totalTicks } = waveform
+      const pixelsPerTick = MIDI_EDITOR_CONFIG.pixelsPerTick * zoomLevel
+      const visibleTicks = Math.max(1, width / pixelsPerTick)
+      const startTick = Math.max(0, scrollX / pixelsPerTick)
+      ctx.fillStyle = 'rgba(77, 208, 225, 0.75)'
+      for (let x = 0; x < w; x++) {
+        const tick = startTick + (x / w) * visibleTicks
+        const peakIdx = Math.min(peaks.length - 1, Math.floor((tick / totalTicks) * peaks.length))
+        const amp = Math.pow(peaks[peakIdx], 0.75)
+        const halfHeight = Math.max(1, amp * (midY - 1))
+        ctx.fillRect(x, midY - halfHeight, 1, halfHeight * 2)
+      }
+
+      const playheadX = ((currentTick - startTick) / visibleTicks) * w
+      if (playheadX >= 0 && playheadX <= w) {
+        ctx.strokeStyle = '#FFE066'
+        ctx.beginPath()
+        ctx.moveTo(playheadX + 0.5, 0)
+        ctx.lineTo(playheadX + 0.5, h)
+        ctx.stroke()
+      }
+    } else {
+      ctx.fillStyle = 'rgba(220, 220, 220, 0.55)'
+      ctx.font = '11px sans-serif'
+      ctx.textAlign = 'center'
+      ctx.textBaseline = 'middle'
+      ctx.fillText('Waveform unavailable', w / 2, h / 2)
+    }
+  }, [waveform, currentTick, scrollX, width, zoomLevel])
+
+  return (
+    <div className="midi-waveform-strip" aria-hidden="true">
+      <div className="midi-waveform-label" style={{ width: headerWidth }}>
+        Waveform
+      </div>
+      <div className="midi-waveform-canvas-wrap">
+        <canvas ref={canvasRef} className="midi-waveform-canvas" />
+      </div>
+    </div>
+  )
 }
 
 // Generate vocal pitch lane labels (high to low for piano roll layout)
@@ -2282,7 +2379,13 @@ export function MidiEditor(): React.JSX.Element {
   const [dimensions, setDimensions] = useState({ width: 800, height: 300 })
   const [scrollX, setScrollX] = useState(0)
   const [scrollY, setScrollY] = useState(0)
-  const { pianoRollZoom: zoomLevel, updateSettings } = useSettingsStore()
+  const {
+    pianoRollZoom: zoomLevel,
+    invertPianoRollVerticalScroll,
+    waveformAudioSourcePath,
+    updateSettings
+  } = useSettingsStore()
+  const showHighwayWaveform = useUIStore((s) => s.showHighwayWaveform)
   const setZoomLevel = useCallback((updater: number | ((prev: number) => number)) => {
     const newZoom = typeof updater === 'function' ? updater(useSettingsStore.getState().pianoRollZoom ?? 2.0) : updater
     updateSettings({ pianoRollZoom: Math.max(0.1, Math.min(5, newZoom)) })
@@ -2314,6 +2417,22 @@ export function MidiEditor(): React.JSX.Element {
   const [activeDifficulty, setActiveDifficulty] = useState<Difficulty>('expert')
   const [tempoEvents, setTempoEvents] = useState<TempoEvent[]>([{ tick: 0, bpm: 120 }])
   const [audioDuration, setAudioDuration] = useState<number>(() => activeSongId ? getAudioDuration(activeSongId) : 0)
+  const [waveformSources, setWaveformSources] = useState<Array<{ filePath: string; filename: string }>>([])
+
+  useEffect(() => {
+    if (!activeSongId) {
+      setWaveformSources([])
+      return
+    }
+
+    const syncSources = (): void => {
+      const sources = getAudioSources(activeSongId)
+      setWaveformSources(sources.map((source) => ({ filePath: source.filePath, filename: source.filename })))
+    }
+
+    syncSources()
+    return onAudioLoaded(activeSongId, syncSources)
+  }, [activeSongId])
 
   // Keep audioDuration in sync when audio loads or song changes
   useEffect(() => {
@@ -2544,6 +2663,10 @@ export function MidiEditor(): React.JSX.Element {
     }, 0)
   }, [displayedInstruments, getLanesForInstrument, getRowHeight])
 
+  const verticalWheelDelta = useCallback((deltaY: number) => {
+    return invertPianoRollVerticalScroll ? -deltaY : deltaY
+  }, [invertPianoRollVerticalScroll])
+
   // Filter notes for current difficulty
   const filteredNotes = useMemo(() => {
     const result = notes.filter(
@@ -2592,13 +2715,14 @@ export function MidiEditor(): React.JSX.Element {
     
     if (e.ctrlKey || e.metaKey) {
       // Zoom
-      const delta = e.deltaY > 0 ? 0.9 : 1.1
+      const wheelY = verticalWheelDelta(e.deltaY)
+      const delta = wheelY > 0 ? 0.9 : 1.1
       setZoomLevel((prev) => Math.max(0.1, Math.min(5, prev * delta)))
     } else if (e.shiftKey) {
       // Shift+scroll = horizontal scroll (timeline)
       isUserScrolling.current = true
       if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current)
-      const hDelta = e.deltaX + e.deltaY
+      const hDelta = e.deltaX + verticalWheelDelta(e.deltaY)
       setScrollX((prev) => {
         const newScrollX = Math.min(maxScrollX, Math.max(0, prev + hDelta))
         if (songStore && !songStore.getState().isPlaying) {
@@ -2615,7 +2739,8 @@ export function MidiEditor(): React.JSX.Element {
     } else {
       // Default: deltaY = vertical, deltaX = horizontal
       const maxScrollY = Math.max(0, totalHeight - dimensions.height + 50)
-      setScrollY((prev) => Math.max(0, Math.min(maxScrollY, prev + e.deltaY)))
+      const wheelY = verticalWheelDelta(e.deltaY)
+      setScrollY((prev) => Math.max(0, Math.min(maxScrollY, prev + wheelY)))
       
       if (Math.abs(e.deltaX) > 0) {
         isUserScrolling.current = true
@@ -2636,7 +2761,7 @@ export function MidiEditor(): React.JSX.Element {
         }, 200)
       }
     }
-  }, [songStore, zoomLevel, totalHeight, dimensions.height, maxScrollX])
+  }, [songStore, zoomLevel, totalHeight, dimensions.height, maxScrollX, verticalWheelDelta])
 
   // Handle scroll on lane headers - vertical scroll
   const handleHeaderScroll = useCallback((e: React.WheelEvent) => {
@@ -2645,20 +2770,22 @@ export function MidiEditor(): React.JSX.Element {
     
     // Vertical scroll - ensure max is at least 0
     const maxScroll = Math.max(0, totalHeight - dimensions.height + 50)
-    setScrollY((prev) => Math.max(0, Math.min(maxScroll, prev + e.deltaY)))
-  }, [totalHeight, dimensions.height])
+    const wheelY = verticalWheelDelta(e.deltaY)
+    setScrollY((prev) => Math.max(0, Math.min(maxScroll, prev + wheelY)))
+  }, [totalHeight, dimensions.height, verticalWheelDelta])
 
   // Handle scroll on editor area (fallback)
   const handleScroll = useCallback((e: React.WheelEvent) => {
     if (e.ctrlKey || e.metaKey) {
       // Zoom
-      const delta = e.deltaY > 0 ? 0.9 : 1.1
+      const wheelY = verticalWheelDelta(e.deltaY)
+      const delta = wheelY > 0 ? 0.9 : 1.1
       setZoomLevel((prev) => prev * delta)
     } else if (e.shiftKey) {
       // Shift+scroll = horizontal scroll (timeline)
       isUserScrolling.current = true
       if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current)
-      const hDelta = e.deltaX + e.deltaY
+      const hDelta = e.deltaX + verticalWheelDelta(e.deltaY)
       setScrollX((prev) => {
         const newScrollX = Math.min(maxScrollX, Math.max(0, prev + hDelta))
         if (songStore && !songStore.getState().isPlaying) {
@@ -2675,7 +2802,8 @@ export function MidiEditor(): React.JSX.Element {
     } else {
       // Default: deltaY = vertical, deltaX = horizontal
       const maxScroll = Math.max(0, totalHeight - dimensions.height + 50)
-      setScrollY((prev) => Math.max(0, Math.min(maxScroll, prev + e.deltaY)))
+      const wheelY = verticalWheelDelta(e.deltaY)
+      setScrollY((prev) => Math.max(0, Math.min(maxScroll, prev + wheelY)))
       
       if (Math.abs(e.deltaX) > 0) {
         isUserScrolling.current = true
@@ -2696,7 +2824,7 @@ export function MidiEditor(): React.JSX.Element {
         }, 200)
       }
     }
-  }, [songStore, zoomLevel, totalHeight, dimensions.height, maxScrollX])
+  }, [songStore, zoomLevel, totalHeight, dimensions.height, maxScrollX, verticalWheelDelta])
 
   // Handle note click - tool-aware, supports flag toggling with modifier toggles
   const handleNoteClick = useCallback(
@@ -3575,6 +3703,10 @@ export function MidiEditor(): React.JSX.Element {
     )
   }
 
+  const selectedWaveformSource = waveformSources.some((s) => s.filePath === waveformAudioSourcePath)
+    ? waveformAudioSourcePath
+    : '__mix__'
+
   return (
     <div className="midi-editor" ref={containerRef}>
       {/* Toolbar */}
@@ -3611,6 +3743,22 @@ export function MidiEditor(): React.JSX.Element {
           <button onClick={() => setZoomLevel((z) => z * 0.8)}>-</button>
           <span>{Math.round(zoomLevel * 100)}%</span>
           <button onClick={() => setZoomLevel((z) => z * 1.25)}>+</button>
+        </div>
+        <div className="midi-waveform-source">
+          <label htmlFor="midi-waveform-source">Waveform:</label>
+          <select
+            id="midi-waveform-source"
+            value={selectedWaveformSource}
+            onChange={(event) => {
+              const value = event.target.value
+              updateSettings({ waveformAudioSourcePath: value === '__mix__' ? undefined : value })
+            }}
+          >
+            <option value="__mix__">Mix</option>
+            {waveformSources.map((source) => (
+              <option key={source.filePath} value={source.filePath}>{source.filename}</option>
+            ))}
+          </select>
         </div>
         {/* Pro Guitar/Bass fret property editor â€” shown when pro notes are selected */}
         {(() => {
@@ -3656,6 +3804,19 @@ export function MidiEditor(): React.JSX.Element {
         <div className="midi-scroll-hint">Scroll: vertical | Shift+Scroll: horizontal | Ctrl+Scroll: zoom</div>
         <MidiShortcutHelpButton />
       </div>
+
+      {showHighwayWaveform && (
+        <PianoRollWaveformStrip
+          songId={activeSongId}
+          headerWidth={MIDI_EDITOR_CONFIG.headerWidth}
+          width={Math.max(dimensions.width, 100)}
+          currentTick={currentTick}
+          scrollX={effectiveScrollX}
+          zoomLevel={zoomLevel}
+          tempoEvents={tempoEvents}
+          sourcePath={waveformAudioSourcePath}
+        />
+      )}
 
       {/* Playhead ruler */}
       <PlayheadRuler

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -19,12 +19,14 @@ export function SettingsModal(): React.JSX.Element | null {
   const enableAutoChart = useSettingsStore((s) => s.enableAutoChart)
   const autoChartOutputDir = useSettingsStore((s) => s.autoChartOutputDir)
   const betaUpdates = useSettingsStore((s) => s.betaUpdates)
+  const invertPianoRollVerticalScroll = useSettingsStore((s) => s.invertPianoRollVerticalScroll)
   const updateSettings = useSettingsStore((s) => s.updateSettings)
   const [recordingAction, setRecordingAction] = useState<HotkeyAction | null>(null)
   const [draftHotkeys, setDraftHotkeys] = useState<AppHotkeys>(hotkeys)
   const [draftEnableAutoChart, setDraftEnableAutoChart] = useState(enableAutoChart)
   const [draftAutoChartOutputDir, setDraftAutoChartOutputDir] = useState(autoChartOutputDir ?? '')
   const [draftBetaUpdates, setDraftBetaUpdates] = useState(betaUpdates)
+  const [draftInvertPianoRollVerticalScroll, setDraftInvertPianoRollVerticalScroll] = useState(invertPianoRollVerticalScroll)
 
   useEffect(() => {
     if (isOpen) {
@@ -32,9 +34,10 @@ export function SettingsModal(): React.JSX.Element | null {
       setDraftEnableAutoChart(enableAutoChart)
       setDraftAutoChartOutputDir(autoChartOutputDir ?? '')
       setDraftBetaUpdates(betaUpdates)
+      setDraftInvertPianoRollVerticalScroll(invertPianoRollVerticalScroll)
       setRecordingAction(null)
     }
-  }, [autoChartOutputDir, enableAutoChart, betaUpdates, hotkeys, isOpen])
+  }, [autoChartOutputDir, enableAutoChart, betaUpdates, hotkeys, invertPianoRollVerticalScroll, isOpen])
 
   useEffect(() => {
     if (!isOpen || draftAutoChartOutputDir.trim()) return
@@ -169,6 +172,19 @@ export function SettingsModal(): React.JSX.Element | null {
               </p>
             </div>
           </section>
+          <section className="settings-preferences-group">
+            <h3 className="settings-hotkey-group-title">MIDI Editor</h3>
+            <div className="settings-preferences-body">
+              <label className="settings-checkbox-row">
+                <input
+                  type="checkbox"
+                  checked={draftInvertPianoRollVerticalScroll}
+                  onChange={(event) => setDraftInvertPianoRollVerticalScroll(event.target.checked)}
+                />
+                <span>Invert piano-roll vertical mouse wheel scroll</span>
+              </label>
+            </div>
+          </section>
           {hasConflicts && (
             <div className="settings-hotkey-conflicts-banner">
               Resolve duplicate bindings before saving. Conflicting shortcuts are highlighted below.
@@ -234,7 +250,8 @@ export function SettingsModal(): React.JSX.Element | null {
                 hotkeys: draftHotkeys,
                 enableAutoChart: draftEnableAutoChart,
                 autoChartOutputDir: draftAutoChartOutputDir.trim() || undefined,
-                betaUpdates: draftBetaUpdates
+                betaUpdates: draftBetaUpdates,
+                invertPianoRollVerticalScroll: draftInvertPianoRollVerticalScroll
               })
               if (draftBetaUpdates !== betaUpdates) {
                 void window.api.setUpdateChannel(draftBetaUpdates)

--- a/src/renderer/src/components/chartPreviewModules/AnimatedHighwayScene.tsx
+++ b/src/renderer/src/components/chartPreviewModules/AnimatedHighwayScene.tsx
@@ -106,13 +106,13 @@ export function AnimatedHighwayScene({
   const snapDivision = useStore(store, (s) => s.snapDivision)
   const isPlaying = useStore(store, (s) => s.isPlaying)
   const assets = useContext(HighwayAssetsContext)
-  const { highwaySpeed: _highwaySpeed, leftyFlip } = useSettingsStore()
+  const { highwaySpeed: _highwaySpeed, leftyFlip, waveformAudioSourcePath } = useSettingsStore()
   const showHighwayWaveform = useUIStore((s) => s.showHighwayWaveform)
 
   const pixelsPerTick = BASE_PIXELS_PER_TICK
 
   // Audio waveform overlay texture (issue #7) — built once per song/audio load.
-  const waveform = useHighwayWaveform(songId, tempoEvents, showHighwayWaveform)
+  const waveform = useHighwayWaveform(songId, tempoEvents, showHighwayWaveform, waveformAudioSourcePath)
 
   // ALL animation state in refs — never triggers React re-renders
   const hitEffectsRef = useRef<HitEffect[]>([])

--- a/src/renderer/src/components/chartPreviewModules/HighwayWaveform.tsx
+++ b/src/renderer/src/components/chartPreviewModules/HighwayWaveform.tsx
@@ -7,42 +7,15 @@
 import { useEffect, useMemo, useState } from 'react'
 import * as THREE from 'three'
 import { TRACK_WIDTH, STRIKE_LINE_POS, HIGHWAY_LENGTH } from './constants'
-import { getAudioBuffers, onAudioLoaded } from '../../services/audioService'
+import { onAudioLoaded } from '../../services/audioService'
+import { buildTickAlignedWaveformPeaks } from '../../services/waveformService'
 import type { TempoEvent } from '../../types'
 
-const TICKS_PER_BEAT = 480
 // Texture resolution: rows along the song (time axis), columns across the track.
 const WAVEFORM_ROWS = 4096
 const WAVEFORM_TEX_WIDTH = 64
 // Cap per-row sample scans so texture build stays fast on long songs.
 const MAX_SAMPLES_PER_ROW = 256
-
-function tickToSeconds(tick: number, tempoEvents: TempoEvent[]): number {
-  let seconds = 0
-  let prevTick = 0
-  let bpm = tempoEvents[0]?.bpm ?? 120
-  for (const event of tempoEvents) {
-    if (event.tick >= tick) break
-    seconds += (event.tick - prevTick) / ((TICKS_PER_BEAT * bpm) / 60)
-    prevTick = event.tick
-    bpm = event.bpm
-  }
-  return seconds + (tick - prevTick) / ((TICKS_PER_BEAT * bpm) / 60)
-}
-
-function secondsToTick(seconds: number, tempoEvents: TempoEvent[]): number {
-  let accSeconds = 0
-  let prevTick = 0
-  let bpm = tempoEvents[0]?.bpm ?? 120
-  for (const event of tempoEvents) {
-    const segmentSeconds = (event.tick - prevTick) / ((TICKS_PER_BEAT * bpm) / 60)
-    if (accSeconds + segmentSeconds >= seconds) break
-    accSeconds += segmentSeconds
-    prevTick = event.tick
-    bpm = event.bpm
-  }
-  return Math.round(prevTick + (seconds - accSeconds) * ((TICKS_PER_BEAT * bpm) / 60))
-}
 
 export interface HighwayWaveformData {
   texture: THREE.CanvasTexture
@@ -56,7 +29,8 @@ export interface HighwayWaveformData {
 export function useHighwayWaveform(
   songId: string,
   tempoEvents: TempoEvent[],
-  enabled: boolean
+  enabled: boolean,
+  sourcePath?: string
 ): HighwayWaveformData | null {
   const [audioVersion, setAudioVersion] = useState(0)
   useEffect(() => onAudioLoaded(songId, () => setAudioVersion((v) => v + 1)), [songId])
@@ -64,39 +38,15 @@ export function useHighwayWaveform(
   const data = useMemo<HighwayWaveformData | null>(() => {
     void audioVersion
     if (!enabled) return null
-    const buffers = getAudioBuffers(songId)
-    if (buffers.length === 0) return null
-    const duration = Math.max(...buffers.map((b) => b.duration))
-    if (!(duration > 0)) return null
-    const totalTicks = Math.max(1, secondsToTick(duration, tempoEvents))
-
-    // Peak amplitude per row. Rows are linear in ticks: each row covers the
-    // audio between its row-start and row-end ticks (tempo-map aware).
-    const channels = buffers.map((b) => ({
-      data: b.getChannelData(0),
-      rate: b.sampleRate
-    }))
-    const peaks = new Float32Array(WAVEFORM_ROWS)
-    let globalPeak = 0
-    let tPrev = 0
-    for (let row = 0; row < WAVEFORM_ROWS; row++) {
-      const tNext = tickToSeconds(((row + 1) / WAVEFORM_ROWS) * totalTicks, tempoEvents)
-      let peak = 0
-      for (const chan of channels) {
-        const s0 = Math.floor(tPrev * chan.rate)
-        const s1 = Math.min(chan.data.length, Math.ceil(tNext * chan.rate))
-        if (s1 <= s0) continue
-        const step = Math.max(1, Math.floor((s1 - s0) / MAX_SAMPLES_PER_ROW))
-        for (let s = s0; s < s1; s += step) {
-          const v = Math.abs(chan.data[s])
-          if (v > peak) peak = v
-        }
-      }
-      peaks[row] = peak
-      if (peak > globalPeak) globalPeak = peak
-      tPrev = tNext
-    }
-    if (globalPeak <= 0) return null
+    const waveform = buildTickAlignedWaveformPeaks({
+      songId,
+      tempoEvents,
+      rows: WAVEFORM_ROWS,
+      sourcePath,
+      maxSamplesPerRow: MAX_SAMPLES_PER_ROW
+    })
+    if (!waveform) return null
+    const { peaks, totalTicks } = waveform
 
     const canvas = document.createElement('canvas')
     canvas.width = WAVEFORM_TEX_WIDTH
@@ -107,7 +57,7 @@ export function useHighwayWaveform(
     ctx.fillStyle = '#FFFFFF'
     for (let row = 0; row < WAVEFORM_ROWS; row++) {
       // Mild power curve lifts quiet passages so they stay visible.
-      const norm = Math.pow(peaks[row] / globalPeak, 0.7)
+      const norm = Math.pow(peaks[row], 0.7)
       const w = Math.max(norm > 0 ? 1 : 0, Math.round(norm * WAVEFORM_TEX_WIDTH))
       if (w === 0) continue
       // Tick 0 at the canvas bottom (v=0 with default flipY).
@@ -121,7 +71,7 @@ export function useHighwayWaveform(
     texture.magFilter = THREE.LinearFilter
     texture.generateMipmaps = false
     return { texture, totalTicks }
-  }, [songId, tempoEvents, enabled, audioVersion])
+  }, [songId, tempoEvents, enabled, audioVersion, sourcePath])
 
   // Free GPU memory when the texture is replaced or unmounted.
   useEffect(() => {

--- a/src/renderer/src/components/chartPreviewModules/UIOverlays.tsx
+++ b/src/renderer/src/components/chartPreviewModules/UIOverlays.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState, useCallback, useRef, useMemo } from 'react'
 import { useProjectStore, getSongStore, useUIStore, useSettingsStore } from '../../stores'
 import type { Instrument, Difficulty, NoteModifiers, VocalNote, VocalPhrase, HarmonyPart, VenueTrackData } from '../../types'
 import type { EditingTool } from './types'
-import { playPitchPreview, stopPitchPreview, seek as seekAudio } from '../../services/audioService'
+import { getAudioSources, onAudioLoaded, playPitchPreview, stopPitchPreview, seek as seekAudio } from '../../services/audioService'
 import { resolveVenuePlaybackState } from './venuePlayback'
 
 function formatVenueLabel(value: string): string {
@@ -56,9 +56,12 @@ export function InstrumentToggles(): React.JSX.Element {
   const { activeSongId } = useProjectStore()
   const showHighwayWaveform = useUIStore((s) => s.showHighwayWaveform)
   const toggleHighwayWaveform = useUIStore((s) => s.toggleHighwayWaveform)
+  const waveformAudioSourcePath = useSettingsStore((s) => s.waveformAudioSourcePath)
+  const updateSettings = useSettingsStore((s) => s.updateSettings)
   const [visibleInstruments, setVisibleInstruments] = useState<Set<Instrument>>(
     new Set(['drums', 'guitar', 'bass', 'vocals', 'keys', 'proKeys', 'proGuitar', 'proBass'])
   )
+  const [waveformSources, setWaveformSources] = useState<Array<{ filePath: string; filename: string }>>([])
 
   useEffect(() => {
     if (!activeSongId) return
@@ -68,6 +71,21 @@ export function InstrumentToggles(): React.JSX.Element {
       if (state.visibleInstruments !== prev.visibleInstruments)
         setVisibleInstruments(new Set(state.visibleInstruments))
     })
+  }, [activeSongId])
+
+  useEffect(() => {
+    if (!activeSongId) {
+      setWaveformSources([])
+      return
+    }
+
+    const syncSources = (): void => {
+      const sources = getAudioSources(activeSongId)
+      setWaveformSources(sources.map((s) => ({ filePath: s.filePath, filename: s.filename })))
+    }
+
+    syncSources()
+    return onAudioLoaded(activeSongId, syncSources)
   }, [activeSongId])
 
   if (!activeSongId) return <></>
@@ -82,6 +100,10 @@ export function InstrumentToggles(): React.JSX.Element {
     { id: 'proGuitar', label: 'Pro Guitar' },
     { id: 'proBass', label: 'Pro Bass' }
   ]
+
+  const selectedWaveformSource = waveformSources.some((s) => s.filePath === waveformAudioSourcePath)
+    ? waveformAudioSourcePath
+    : '__mix__'
 
   return (
     <div className="instrument-toggles">
@@ -101,6 +123,22 @@ export function InstrumentToggles(): React.JSX.Element {
       >
         Waveform
       </button>
+      <select
+        className="waveform-source-select"
+        title="Choose which audio source drives waveform rendering"
+        value={selectedWaveformSource}
+        onChange={(event) => {
+          const value = event.target.value
+          updateSettings({ waveformAudioSourcePath: value === '__mix__' ? undefined : value })
+        }}
+      >
+        <option value="__mix__">Waveform: Mix</option>
+        {waveformSources.map((source) => (
+          <option key={source.filePath} value={source.filePath}>
+            Waveform: {source.filename}
+          </option>
+        ))}
+      </select>
     </div>
   )
 }

--- a/src/renderer/src/services/waveformService.ts
+++ b/src/renderer/src/services/waveformService.ts
@@ -1,0 +1,87 @@
+import type { TempoEvent } from '../types'
+import { getAudioBufferForPath, getAudioBuffers, tickToSeconds } from './audioService'
+
+const TICKS_PER_BEAT = 480
+
+function secondsToTick(seconds: number, tempoEvents: TempoEvent[]): number {
+  let accSeconds = 0
+  let prevTick = 0
+  let bpm = tempoEvents[0]?.bpm ?? 120
+
+  for (const event of tempoEvents) {
+    const segmentSeconds = (event.tick - prevTick) / ((TICKS_PER_BEAT * bpm) / 60)
+    if (accSeconds + segmentSeconds >= seconds) break
+    accSeconds += segmentSeconds
+    prevTick = event.tick
+    bpm = event.bpm
+  }
+
+  return Math.round(prevTick + (seconds - accSeconds) * ((TICKS_PER_BEAT * bpm) / 60))
+}
+
+function resolveWaveformBuffers(songId: string, sourcePath?: string): AudioBuffer[] {
+  if (sourcePath) {
+    const single = getAudioBufferForPath(songId, sourcePath)
+    if (single) return [single]
+  }
+  return getAudioBuffers(songId)
+}
+
+export interface TickAlignedWaveform {
+  peaks: Float32Array
+  totalTicks: number
+}
+
+export function buildTickAlignedWaveformPeaks({
+  songId,
+  tempoEvents,
+  rows,
+  sourcePath,
+  maxSamplesPerRow = 256
+}: {
+  songId: string
+  tempoEvents: TempoEvent[]
+  rows: number
+  sourcePath?: string
+  maxSamplesPerRow?: number
+}): TickAlignedWaveform | null {
+  const buffers = resolveWaveformBuffers(songId, sourcePath)
+  if (buffers.length === 0) return null
+
+  const duration = Math.max(...buffers.map((b) => b.duration))
+  if (!(duration > 0) || !(rows > 0)) return null
+
+  const totalTicks = Math.max(1, secondsToTick(duration, tempoEvents))
+  const channels = buffers.map((b) => ({ data: b.getChannelData(0), rate: b.sampleRate }))
+  const peaks = new Float32Array(rows)
+
+  let globalPeak = 0
+  let tPrev = 0
+  for (let row = 0; row < rows; row++) {
+    const tNext = tickToSeconds(((row + 1) / rows) * totalTicks, tempoEvents)
+    let peak = 0
+
+    for (const chan of channels) {
+      const s0 = Math.floor(tPrev * chan.rate)
+      const s1 = Math.min(chan.data.length, Math.ceil(tNext * chan.rate))
+      if (s1 <= s0) continue
+      const step = Math.max(1, Math.floor((s1 - s0) / maxSamplesPerRow))
+      for (let s = s0; s < s1; s += step) {
+        const v = Math.abs(chan.data[s])
+        if (v > peak) peak = v
+      }
+    }
+
+    peaks[row] = peak
+    if (peak > globalPeak) globalPeak = peak
+    tPrev = tNext
+  }
+
+  if (globalPeak <= 0) return null
+
+  for (let i = 0; i < peaks.length; i++) {
+    peaks[i] = peaks[i] / globalPeak
+  }
+
+  return { peaks, totalTicks }
+}

--- a/src/renderer/src/stores/projectStore.ts
+++ b/src/renderer/src/stores/projectStore.ts
@@ -58,9 +58,11 @@ const defaultSettings: AppSettings = {
   snapDivision: 4,
   lastOpenedFolder: undefined,
   leftyFlip: false,
+  waveformAudioSourcePath: undefined,
   enableAutoChart: true,
   autoChartOutputDir: undefined,
   betaUpdates: false,
+  invertPianoRollVerticalScroll: false,
   hotkeys: cloneDefaultHotkeys()
 }
 

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -264,9 +264,11 @@ export interface AppSettings {
   snapDivision: number // 1-32
   lastOpenedFolder?: string
   leftyFlip: boolean // Mirror highway left-right for left-handed players
+  waveformAudioSourcePath?: string // Optional audio source path used for waveform rendering (undefined = mixed)
   enableAutoChart: boolean
   autoChartOutputDir?: string
   betaUpdates: boolean // Opt into beta/pre-release auto-updates
+  invertPianoRollVerticalScroll: boolean // Reverse vertical wheel direction in the piano roll
   hotkeys: AppHotkeys
 }
 


### PR DESCRIPTION
## What does this PR do?

Add dropdown for waveform sources and horizontal piano roll setting

## Related Issue

<!-- Link to the issue this PR addresses, e.g. "Closes #123" -->

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Tested manually in the app
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
