### PR TITLE
fix: stem-separation stall watchdog, settings directory fallback, latin-1 smart punctuation, and explorer auto-refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ docs/.vitepress/cache/
 
 # Screenshot harness fixtures (local-only sample projects)
 scripts/screenshots/fixtures/
+
+# Plans
+docs/plans/

--- a/resources/strum/strum_worker.py
+++ b/resources/strum/strum_worker.py
@@ -158,6 +158,33 @@ def _diagnose_basic_pitch_failure(exc: BaseException) -> None:
     )
 
 
+def _sanitize_string_to_latin1(s: str) -> str:
+    if not s:
+        return s
+    _SMART_MAP = {
+        "\u2018": "'", "\u2019": "'", "\u201a": "'", "\u201b": "'",
+        "\u201c": '"', "\u201d": '"', "\u201e": '"', "\u201f": '"',
+        "\u2013": "-", "\u2014": "-", "\u2026": "...",
+        "\u266a": "", "\u266b": "", "\u266c": "", "\u2669": "",
+        "\xa0": " ",
+    }
+    for k, v in _SMART_MAP.items():
+        if k in s:
+            s = s.replace(k, v)
+    try:
+        return s.encode("latin-1", errors="ignore").decode("latin-1")
+    except Exception:
+        return s
+
+
+def _sanitize_vocal_phrases(phrases) -> None:
+    for phrase in phrases or []:
+        for note in getattr(phrase, "notes", []) or []:
+            lyric = getattr(note, "lyric", None)
+            if lyric:
+                note.lyric = _sanitize_string_to_latin1(lyric)
+
+
 def _run_separation_subprocess(cmd: "list[str]", label: str) -> "tuple[int, int]":
     """Run a stem-separation subprocess supervised by a stall watchdog.
 
@@ -177,9 +204,10 @@ def _run_separation_subprocess(cmd: "list[str]", label: str) -> "tuple[int, int]
 
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     last_activity = time.time()
+    completed_progress = False
 
     def _pump() -> None:
-        nonlocal last_activity
+        nonlocal last_activity, completed_progress
         stream = proc.stdout
         if stream is None:
             return
@@ -191,6 +219,13 @@ def _run_separation_subprocess(cmd: "list[str]", label: str) -> "tuple[int, int]
                 if not chunk:
                     break
                 last_activity = time.time()
+                try:
+                    # Detect progress bar completion to bypass idle timeout during post-completion write.
+                    text = chunk.decode("utf-8", errors="ignore")
+                    if "100%" in text:
+                        completed_progress = True
+                except Exception:
+                    pass
                 try:
                     sys.stderr.buffer.write(chunk)
                     sys.stderr.flush()
@@ -215,7 +250,7 @@ def _run_separation_subprocess(cmd: "list[str]", label: str) -> "tuple[int, int]
                 f"{label} exceeded the {AUDIO_SEPARATION_TIMEOUT_SEC}s hard limit. "
                 "Set OCTAVE_STRUM_SEPARATION_TIMEOUT_SEC to raise it."
             )
-        if now - last_activity > AUDIO_SEPARATION_IDLE_TIMEOUT_SEC:
+        if not completed_progress and now - last_activity > AUDIO_SEPARATION_IDLE_TIMEOUT_SEC:
             proc.kill()
             raise RuntimeError(
                 f"{label} stalled (no output for {AUDIO_SEPARATION_IDLE_TIMEOUT_SEC}s) "
@@ -945,10 +980,7 @@ def build_pipeline(
                 "\xa0": " ",
             }
             def _sanitize_lyric(s: str) -> str:
-                for k, v in _SMART_MAP.items():
-                    if k in s:
-                        s = s.replace(k, v)
-                return s.encode("latin-1", errors="ignore").decode("latin-1")
+                return _sanitize_string_to_latin1(s)
 
             words = []
             for entry in payload.get("transcription", []):
@@ -1007,9 +1039,12 @@ def build_pipeline(
                     flags=re.IGNORECASE,
                 ).strip()
                 if artist and title:
-                    return artist.strip(), title
+                    return _sanitize_string_to_latin1(artist.strip()), _sanitize_string_to_latin1(title)
 
-            return super().parse_filename(path)
+            res = super().parse_filename(path)
+            if isinstance(res, tuple) and len(res) == 2:
+                return _sanitize_string_to_latin1(res[0]), _sanitize_string_to_latin1(res[1])
+            return res
 
         @property
         def vocals_charter(self):
@@ -1509,8 +1544,17 @@ def build_pipeline(
         def transcribe_vocals(self, vocals_stem: Path, artist: str, title: str):
             print(f"[OCTAVE] >>> transcribe_vocals(stem={vocals_stem.name})", file=sys.stderr, flush=True)
             try:
-                result = super().transcribe_vocals(vocals_stem, artist, title)
+                result = super().transcribe_vocals(
+                    vocals_stem,
+                    _sanitize_string_to_latin1(artist),
+                    _sanitize_string_to_latin1(title),
+                )
+                if not result:
+                    return result
                 lead = result[0] if isinstance(result, tuple) and len(result) > 0 else None
+                harmonies = result[1] if isinstance(result, tuple) and len(result) > 1 else None
+                _sanitize_vocal_phrases(lead)
+                _sanitize_vocal_phrases(harmonies)
                 n = len(lead) if lead else 0
                 print(f"[OCTAVE] <<< transcribe_vocals produced {n} lead phrases", file=sys.stderr, flush=True)
                 return result
@@ -1550,6 +1594,10 @@ def build_pipeline(
                 result = super().analyze_audio(audio_path, artist, title)
                 if USER_TEMPO_MAP and isinstance(result, dict):
                     result["tempo_bpm"] = round(USER_TEMPO_MAP[0][1], 3)
+                if isinstance(result, dict):
+                    for k in ("album", "year", "genre"):
+                        if k in result:
+                            result[k] = _sanitize_string_to_latin1(result[k])
                 return result
 
             logger = logging.getLogger(__name__)
@@ -1600,9 +1648,9 @@ def build_pipeline(
                 "duration_ms": int(duration_sec * 1000),
                 "duration_sec": duration_sec,
                 "preview_start_ms": int(preview_sec * 1000),
-                "album": metadata.get("album", ""),
-                "year": metadata.get("year", ""),
-                "genre": metadata.get("genre", ""),
+                "album": _sanitize_string_to_latin1(metadata.get("album", "")),
+                "year": _sanitize_string_to_latin1(metadata.get("year", "")),
+                "genre": _sanitize_string_to_latin1(metadata.get("genre", "")),
             }
 
     tracks = enabled_tracks or {}

--- a/resources/strum/strum_worker.py
+++ b/resources/strum/strum_worker.py
@@ -158,7 +158,9 @@ def _diagnose_basic_pitch_failure(exc: BaseException) -> None:
     )
 
 
-def _sanitize_string_to_latin1(s: str) -> str:
+def _sanitize_string_to_latin1(s):
+    if not isinstance(s, str):
+        return s
     if not s:
         return s
     _SMART_MAP = {
@@ -220,10 +222,12 @@ def _run_separation_subprocess(cmd: "list[str]", label: str) -> "tuple[int, int]
                     break
                 last_activity = time.time()
                 try:
-                    # Detect progress bar completion to bypass idle timeout during post-completion write.
+                    # A completed progress bar can legitimately be followed by
+                    # a quiet post-processing write. Re-arm the idle watchdog
+                    # when a later bar starts so a subsequent stall is caught.
                     text = chunk.decode("utf-8", errors="ignore")
-                    if "100%" in text:
-                        completed_progress = True
+                    for progress in re.finditer(r"(?<!\d)(100|[1-9]?\d)%", text):
+                        completed_progress = progress.group(1) == "100"
                 except Exception:
                     pass
                 try:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -944,6 +944,7 @@ ipcMain.handle('folder:scan', async (_event, folderPath: string) => {
     }
   } catch (error) {
     console.error('Error scanning folder:', error)
+    throw error
   }
 
   return songs

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -897,10 +897,6 @@ ipcMain.handle('dialog:openLyricsFile', async () => {
 
 // Scan folder for song directories (folders containing song.ini)
 ipcMain.handle('folder:scan', async (_event, folderPath: string) => {
-  // Set allowedProjectPath so auto-reloaded folders also get security boundary
-  if (!allowedProjectPath) {
-    allowedProjectPath = resolve(folderPath)
-  }
   const songs: Array<{ id: string; path: string; name: string; addedAt: number }> = []
 
   try {
@@ -945,6 +941,13 @@ ipcMain.handle('folder:scan', async (_event, folderPath: string) => {
   } catch (error) {
     console.error('Error scanning folder:', error)
     throw error
+  }
+
+  // Only establish the security boundary after a successful scan. This lets a
+  // failed saved-folder scan fall back to a valid folder without leaving paths
+  // pinned to the missing or inaccessible location.
+  if (!allowedProjectPath) {
+    allowedProjectPath = resolve(folderPath)
   }
 
   return songs

--- a/src/main/strumIntegration/runner.ts
+++ b/src/main/strumIntegration/runner.ts
@@ -278,7 +278,7 @@ export async function resolvePythonCommand(runId?: string): Promise<PythonComman
 
 function splitLines(chunk: string, remainder: string): { lines: string[]; remainder: string } {
   const combined = remainder + chunk
-  const parts = combined.split(/\r?\n/)
+  const parts = combined.split(/\r\n|\r|\n/)
   return {
     lines: parts.slice(0, -1),
     remainder: parts.at(-1) ?? ''
@@ -589,6 +589,21 @@ export async function runAutoChart(options: Omit<AutoChartRunOptions, 'cacheDir'
             lastProgressPercent = Math.max(lastProgressPercent, event.percent)
           }
         })) {
+          // Check if it's a tqdm progress line (e.g. " 10%|██      |")
+          const tqdmMatch = line.match(/(\d+)%\|/)
+          if (tqdmMatch) {
+            const stagePercent = parseInt(tqdmMatch[1], 10)
+            const percent = normalizeGlobalPercent(lastProgressStage, stagePercent)
+            broadcast('strum:progress', {
+              runId,
+              stage: lastProgressStage,
+              message: line.trim(),
+              percent
+            } satisfies AutoChartProgressEvent)
+            lastProgressPercent = Math.max(lastProgressPercent, percent)
+            continue
+          }
+
           const parsed = parseAutoChartProgressLine(runId, line)
           if (parsed) {
             const incomingRank = getStageRank(parsed.stage)

--- a/src/renderer/src/components/ProjectExplorer.tsx
+++ b/src/renderer/src/components/ProjectExplorer.tsx
@@ -155,8 +155,17 @@ function SongItem({
 }
 
 export function ProjectExplorer(): React.JSX.Element {
-  const { loadedFolderPath, songIds, activeSongId, libraryLoadVersion, setActiveSong, setLoadedFolder, addSong, removeSong } =
-    useProjectStore()
+  const {
+    loadedFolderPath,
+    songIds,
+    activeSongId,
+    libraryLoadVersion,
+    setActiveSong,
+    setPendingActiveSong,
+    setLoadedFolder,
+    addSong,
+    removeSong
+  } = useProjectStore()
   const { lastOpenedFolder, updateSettings } = useSettingsStore()
   const [isLoading, setIsLoading] = useState(false)
   const [showNewSongDialog, setShowNewSongDialog] = useState(false)
@@ -172,7 +181,8 @@ export function ProjectExplorer(): React.JSX.Element {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [_expandedFolders, _setExpandedFolders] = useState<Set<string>>(new Set())
 
-  // Load a folder's songs (shared between initial load and handleOpenFolder)
+  // Load a folder's songs (shared between initial load and handleOpenFolder).
+  // Cached metadata renders immediately while the filesystem scan validates it.
   const loadFolder = useCallback(async (folderPath: string, preferredActiveId?: string | null) => {
     const generation = ++loadGenerationRef.current
     setIsLoading(true)
@@ -247,7 +257,7 @@ export function ProjectExplorer(): React.JSX.Element {
 
       const songFolders = await window.api.scanFolder(folderPath)
       if (!isCurrentLoad()) return
-      const freshResults = await Promise.all(
+      const freshSongs = await Promise.all(
         songFolders.map(async (songFolder): Promise<CachedLibrarySong> => {
           try {
             const iniData = await window.api.readSongIni(songFolder.path)
@@ -285,7 +295,6 @@ export function ProjectExplorer(): React.JSX.Element {
         })
       )
       if (!isCurrentLoad()) return
-      const freshSongs = freshResults
       setSongAddedTimes(new Map(freshSongs.map((song) => [song.id, song.addedAt ?? 0])))
 
       const freshIds = new Set(freshSongs.map(({ id }) => id))
@@ -302,9 +311,11 @@ export function ProjectExplorer(): React.JSX.Element {
       })
       if (!isCurrentLoad()) return
 
-      const currentActiveId = useProjectStore.getState().activeSongId
-      if (preferredActiveId && freshIds.has(preferredActiveId)) {
-        setActiveSong(preferredActiveId)
+      const { activeSongId: currentActiveId, pendingActiveSongId } = useProjectStore.getState()
+      if (pendingActiveSongId) setPendingActiveSong(null)
+      const requestedActiveId = pendingActiveSongId ?? preferredActiveId
+      if (requestedActiveId && freshIds.has(requestedActiveId)) {
+        setActiveSong(requestedActiveId)
       } else if ((!currentActiveId || !freshIds.has(currentActiveId)) && freshSongs.length > 0) {
         const firstSong = organizeLibrarySongs(
           freshSongs.map(({ id, metadata }) => ({ id, name: metadata.name, artist: metadata.artist })),
@@ -315,11 +326,31 @@ export function ProjectExplorer(): React.JSX.Element {
         setActiveSong(firstSong.id)
       }
     } catch (error) {
-      if (isCurrentLoad()) console.error(`Failed to load library ${folderPath}:`, error)
+      if (!isCurrentLoad()) return
+      console.error(`Failed to load library ${folderPath}:`, error)
+      const message = error instanceof Error ? error.message : String(error)
+      try {
+        const defaultPath = await window.api.getDefaultAutoChartOutputDir()
+        if (defaultPath !== folderPath) {
+          alert(
+            `Could not open this folder: ${message}\n\nOpening the default auto-chart folder instead.`
+          )
+          updateSettings({ lastOpenedFolder: defaultPath })
+          for (const songId of useProjectStore.getState().songIds) {
+            removeSongStore(songId)
+          }
+          setLoadedFolder(defaultPath)
+        } else {
+          alert(`Could not open the default auto-chart folder: ${message}`)
+        }
+      } catch (fallbackError) {
+        console.error('Failed to open the default auto-chart folder:', fallbackError)
+        alert(`Could not open this folder: ${message}`)
+      }
     } finally {
       if (loadGenerationRef.current === generation) setIsLoading(false)
     }
-  }, [addSong, removeSong, setActiveSong, setLoadedFolder])
+  }, [addSong, removeSong, setActiveSong, setLoadedFolder, setPendingActiveSong, updateSettings])
 
   // Auto-load last opened folder on startup
   useEffect(() => {
@@ -564,6 +595,7 @@ export function ProjectExplorer(): React.JSX.Element {
   const handleOpenFolder = async (): Promise<void> => {
     try {
       setIsLoading(true)
+      setPendingActiveSong(null)
 
       // 1. Open folder dialog
       const folderPath = await window.api.openFolder()
@@ -595,6 +627,7 @@ export function ProjectExplorer(): React.JSX.Element {
     if (!loadedFolderPath) return
     try {
       setIsLoading(true)
+      setPendingActiveSong(null)
 
       // Clean up existing song stores
       const preferredActiveId = activeSongId

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -41,7 +41,7 @@ const AUTO_CHART_STAGE_ORDER: Record<string, number> = {
 }
 
 export function Toolbar(): React.JSX.Element {
-  const { activeSongId, setLoadedFolder } = useProjectStore()
+  const { activeSongId, setLoadedFolder, setPendingActiveSong } = useProjectStore()
   const isExportModalOpen = useUIStore((s) => s.isExportModalOpen)
   const setExportModalOpen = useUIStore((s) => s.setExportModalOpen)
   const validationIssues = useUIStore((s) => s.validationIssues)
@@ -376,7 +376,7 @@ export function Toolbar(): React.JSX.Element {
   }, [updateSettings])
 
   const loadProjectFolder = useCallback(
-    async (folderPath: string): Promise<void> => {
+    (folderPath: string, preferredActiveSongId?: string): void => {
       // ProjectExplorer owns metadata-first loading and IndexedDB cache validation.
       // Updating the shared folder path triggers that loader without eagerly parsing
       // every MIDI/chart on the toolbar action path.
@@ -386,15 +386,16 @@ export function Toolbar(): React.JSX.Element {
         for (const songId of project.songIds) removeSongStore(songId)
       }
       setLoadedFolder(folderPath)
+      setPendingActiveSong(preferredActiveSongId ?? null)
     },
-    [setLoadedFolder, updateSettings]
+    [setLoadedFolder, setPendingActiveSong, updateSettings]
   )
 
   const handleOpenFolder = async (): Promise<void> => {
     try {
       const folderPath = await window.api.openFolder()
       if (!folderPath) return
-      await loadProjectFolder(folderPath)
+      loadProjectFolder(folderPath)
     } catch (error) {
       console.error('Failed to open folder:', error)
     }
@@ -460,11 +461,15 @@ export function Toolbar(): React.JSX.Element {
         }
       })
 
-      if (event.success) {
+      const newSongId = event.success && event.songFolders.length > 0
+        ? event.songFolders[0].split(/[\\/]/).pop()
+        : undefined
+
+      if (event.outputDir) {
         updateSettings({ autoChartOutputDir: event.outputDir, lastOpenedFolder: event.outputDir })
         // Optionally pull the source video for any URL inputs into their
         // resulting song folders so it shows up in the timeline / in-game.
-        if (autoChartDownloadVideo && event.urlSongFolders && event.urlSongFolders.length > 0) {
+        if (event.success && autoChartDownloadVideo && event.urlSongFolders && event.urlSongFolders.length > 0) {
           void Promise.allSettled(
             event.urlSongFolders.map((entry) =>
               window.api.downloadVideoUrl(entry.songFolder, entry.url).catch((err) => {
@@ -473,11 +478,14 @@ export function Toolbar(): React.JSX.Element {
               })
             )
           ).then(() => {
-            void loadProjectFolder(event.outputDir)
+            loadProjectFolder(event.outputDir, newSongId)
           })
         } else {
-          void loadProjectFolder(event.outputDir)
+          loadProjectFolder(event.outputDir, newSongId)
         }
+      }
+
+      if (event.success) {
         setAutoChartCloseCountdown(5)
       }
     })

--- a/src/renderer/src/stores/projectStore.test.ts
+++ b/src/renderer/src/stores/projectStore.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 let useSettingsStore: (typeof import('./projectStore'))['useSettingsStore']
+let useProjectStore: (typeof import('./projectStore'))['useProjectStore']
 
 describe('Auto-Chart settings', () => {
   beforeAll(async () => {
@@ -15,10 +16,13 @@ describe('Auto-Chart settings', () => {
         return values.size
       }
     })
-    ;({ useSettingsStore } = await import('./projectStore'))
+    ;({ useProjectStore, useSettingsStore } = await import('./projectStore'))
   })
 
-  afterEach(() => useSettingsStore.getState().resetSettings())
+  afterEach(() => {
+    useSettingsStore.getState().resetSettings()
+    useProjectStore.getState().clearProject()
+  })
 
   it('keeps reusable run preferences in the persisted settings store', () => {
     useSettingsStore.getState().updateSettings({
@@ -75,5 +79,18 @@ describe('Auto-Chart settings', () => {
         proKeys: false
       }
     })
+  })
+
+  it('keeps an auto-chart selection for an in-place refresh only', () => {
+    const project = useProjectStore.getState()
+    project.setLoadedFolder('/songs')
+    project.setPendingActiveSong('new-song')
+    project.setLoadedFolder('/songs')
+
+    expect(useProjectStore.getState().pendingActiveSongId).toBe('new-song')
+
+    useProjectStore.getState().setLoadedFolder('/other-songs')
+
+    expect(useProjectStore.getState().pendingActiveSongId).toBeNull()
   })
 })

--- a/src/renderer/src/stores/projectStore.ts
+++ b/src/renderer/src/stores/projectStore.ts
@@ -6,11 +6,13 @@ import { cloneDefaultHotkeys } from '../utils/hotkeys'
 
 interface ProjectStore extends ProjectState {
   libraryLoadVersion: number
+  pendingActiveSongId: string | null
   // Actions
   setLoadedFolder: (path: string | null) => void
   addSong: (songId: string) => void
   removeSong: (songId: string) => void
   setActiveSong: (songId: string | null) => void
+  setPendingActiveSong: (songId: string | null) => void
   clearProject: () => void
 }
 
@@ -20,6 +22,7 @@ export const useProjectStore = create<ProjectStore>()((set) => ({
   songIds: [],
   activeSongId: null,
   libraryLoadVersion: 0,
+  pendingActiveSongId: null,
 
   // Actions
   setLoadedFolder: (path) =>
@@ -30,6 +33,7 @@ export const useProjectStore = create<ProjectStore>()((set) => ({
             loadedFolderPath: path,
             songIds: [],
             activeSongId: null,
+            pendingActiveSongId: null,
             libraryLoadVersion: state.libraryLoadVersion + 1
           }
     ),
@@ -49,13 +53,16 @@ export const useProjectStore = create<ProjectStore>()((set) => ({
 
   setActiveSong: (songId) => set({ activeSongId: songId }),
 
+  setPendingActiveSong: (songId) => set({ pendingActiveSongId: songId }),
+
   clearProject: () =>
     set((state) => ({
       loadedFolderPath: null,
       songIds: [],
       activeSongId: null,
+      pendingActiveSongId: null,
       libraryLoadVersion: state.libraryLoadVersion + 1
-    }))
+    })),
 }))
 
 // App settings store (persisted)


### PR DESCRIPTION
## Summary

- Prevents the stem-separation idle watchdog from killing a completed separation while its output is being written on slow filesystems.
- Streams carriage-return (`\r`) tqdm progress into the Auto-Chart UI.
- Makes folder scan errors visible to the renderer and falls back cleanly to the configured default Auto-Chart directory.
- Sanitizes filenames, metadata, and the live vocal-transcription result to Latin-1-safe text before MIDI/song metadata is written.
- Refreshes the cached, metadata-first Project Explorer after Auto-Chart completes and selects the newly created song without regressing `beta`'s IndexedDB cache/validation flow.

## Validation

- `python3 -m py_compile resources/strum/strum_worker.py`
- `npm test` — 13 files, 76 tests passed
- `npm run build` — TypeScript checks and production Electron build passed
- `git diff --check`

The project-store regression test covers the one-shot preferred selection lifecycle. Final code review found and resolved the live vocal-sanitization and cached fallback-store collision paths.