### PR TITLE
fix: make Snap to Grid non-destructive (#22)

### DIFF
--- a/src/renderer/src/components/MidiEditor.tsx
+++ b/src/renderer/src/components/MidiEditor.tsx
@@ -3812,8 +3812,8 @@ export function MidiEditor(): React.JSX.Element {
           className="midi-snap-to-grid-button"
           title={
             selectedNoteIds.length > 0
-              ? `Snap ${selectedNoteIds.length} selected note(s) to the 1/${snapDivision} grid`
-              : `Snap ALL notes to the 1/${snapDivision} grid`
+              ? `Nudge ${selectedNoteIds.length} selected note(s) that sit just off the 1/${snapDivision} grid onto it (off-grid notes are left alone)`
+              : `Nudge notes that sit just off the 1/${snapDivision} grid onto it (off-grid notes are left alone)`
           }
           onClick={() => songStore?.getState().snapNotesToGrid()}
         >

--- a/src/renderer/src/stores/songStore.ts
+++ b/src/renderer/src/stores/songStore.ts
@@ -2,6 +2,11 @@
 import { create, StateCreator } from 'zustand'
 import { temporal, TemporalState } from 'zundo'
 import { v4 as uuidv4 } from 'uuid'
+import {
+  gridTicksForDivision,
+  snapEntriesToGrid,
+  SNAP_TO_GRID_TOLERANCE_FRACTION
+} from '../utils/snapToGrid'
 import type {
   SongData,
   SongEditorState,
@@ -35,7 +40,7 @@ interface SongStoreState extends SongEditorState {
   deleteNote: (noteId: string) => void
   deleteSelectedNotes: () => void
   swapLanes: (instrument: Instrument, laneA: string, laneB: string, difficulty?: Difficulty | 'all') => void
-  snapNotesToGrid: (division?: number) => void
+  snapNotesToGrid: (division?: number, toleranceTicks?: number) => void
 
   // Selection actions
   selectNote: (noteId: string, addToSelection?: boolean) => void
@@ -274,48 +279,47 @@ const createSongStoreSlice: StateCreator<SongStoreState> = (set) => {
     // therefore tempo-independent: a note at tick T moves to the nearest multiple
     // of (480 / division) ticks. Sustained notes keep their end aligned to the
     // grid as well so durations stay clean.
-    snapNotesToGrid: (division) =>
+    //
+    // Two behaviours (issue #22) keep snapping non-destructive:
+    //   1. Tolerance — a note is only moved when it already lies within
+    //      `toleranceTicks` of a grid line, so correctly-placed finer-subdivision
+    //      notes (syncopation, fills) are left untouched instead of being dragged
+    //      onto a coarser beat. Defaults to a fraction of the grid spacing.
+    //   2. De-duplication — notes that collapse onto the same
+    //      instrument|difficulty|lane|tick (or vocal part|tick) are merged,
+    //      keeping the longest sustain, so snapping never silently stacks notes
+    //      on top of each other (which the validator flags and which makes notes
+    //      "disappear" in game).
+    snapNotesToGrid: (division, toleranceTicks) =>
       set((state) => {
         const div = division ?? state.snapDivision
         if (!div || div <= 0) return {}
-        const snapTicks = 480 / div
-        const snap = (t: number): number => Math.round(t / snapTicks) * snapTicks
+        const gridTicks = gridTicksForDivision(div)
+        const tolerance = toleranceTicks ?? gridTicks * SNAP_TO_GRID_TOLERANCE_FRACTION
 
         const selectedNotes = new Set(state.selectedNoteIds)
         const selectedVocals = new Set(state.selectedVocalNoteIds)
         const hasSelection = selectedNotes.size > 0 || selectedVocals.size > 0
 
-        const snapEntry = <T extends { tick: number; duration: number }>(n: T): T => {
-          const newTick = snap(n.tick)
-          let newDuration = n.duration
-          if (n.duration > 0) {
-            newDuration = Math.max(0, snap(n.tick + n.duration) - newTick)
-          }
-          if (newTick === n.tick && newDuration === n.duration) return n
-          return { ...n, tick: newTick, duration: newDuration }
-        }
-
-        let changed = false
-
-        const notes = state.song.notes.map((n) => {
-          if (hasSelection && !selectedNotes.has(n.id)) return n
-          const snapped = snapEntry(n)
-          if (snapped !== n) changed = true
-          return snapped
+        const noteResult = snapEntriesToGrid(state.song.notes, {
+          gridTicks,
+          toleranceTicks: tolerance,
+          isEligible: (n) => !hasSelection || selectedNotes.has(n.id),
+          keyOf: (n) => `${n.instrument}|${n.difficulty}|${n.lane}|${n.tick}`
         })
 
-        const vocalNotes = state.song.vocalNotes.map((n) => {
-          if (hasSelection && !selectedVocals.has(n.id)) return n
-          const snapped = snapEntry(n)
-          if (snapped !== n) changed = true
-          return snapped
+        const vocalResult = snapEntriesToGrid(state.song.vocalNotes, {
+          gridTicks,
+          toleranceTicks: tolerance,
+          isEligible: (n) => !hasSelection || selectedVocals.has(n.id),
+          keyOf: (n) => `${n.harmonyPart}|${n.tick}`
         })
 
-        if (!changed) return {}
+        if (!noteResult.changed && !vocalResult.changed) return {}
 
         // Preserve the tick-sorted invariant after snapping.
-        notes.sort((a, b) => a.tick - b.tick)
-        vocalNotes.sort((a, b) => a.tick - b.tick)
+        const notes = [...noteResult.entries].sort((a, b) => a.tick - b.tick)
+        const vocalNotes = [...vocalResult.entries].sort((a, b) => a.tick - b.tick)
 
         return {
           song: { ...state.song, notes, vocalNotes },

--- a/src/renderer/src/utils/snapToGrid.test.ts
+++ b/src/renderer/src/utils/snapToGrid.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import {
+  snapTickToGrid,
+  gridTicksForDivision,
+  snapEntriesToGrid,
+  SNAP_TO_GRID_TOLERANCE_FRACTION
+} from './snapToGrid'
+
+interface TestNote {
+  id: string
+  tick: number
+  duration: number
+  lane: string
+}
+
+let idCounter = 0
+const mkNote = (over: Partial<TestNote>): TestNote => ({
+  id: `n${idCounter++}`,
+  tick: 0,
+  duration: 0,
+  lane: 'snare',
+  ...over
+})
+
+const snapAll = <T extends { tick: number; duration: number }>(
+  entries: T[],
+  gridTicks: number,
+  keyOf: (e: T) => string,
+  toleranceTicks = Infinity
+): { entries: T[]; changed: boolean } =>
+  snapEntriesToGrid(entries, { gridTicks, toleranceTicks, isEligible: () => true, keyOf })
+
+describe('snapTickToGrid', () => {
+  it('rounds to the nearest grid line', () => {
+    expect(snapTickToGrid(482, 120)).toBe(480)
+    expect(snapTickToGrid(540, 120)).toBe(600) // midpoint rounds up
+    expect(snapTickToGrid(7, 15)).toBe(0)
+    expect(snapTickToGrid(8, 15)).toBe(15)
+  })
+
+  it('returns the tick unchanged for a non-positive grid', () => {
+    expect(snapTickToGrid(123, 0)).toBe(123)
+  })
+})
+
+describe('gridTicksForDivision', () => {
+  it('computes grid spacing at 480 PPQ', () => {
+    expect(gridTicksForDivision(4)).toBe(120)
+    expect(gridTicksForDivision(32)).toBe(15)
+    expect(gridTicksForDivision(1)).toBe(480)
+  })
+})
+
+describe('snapEntriesToGrid', () => {
+  it('nudges a slightly-off note onto the nearest grid line', () => {
+    const notes = [mkNote({ tick: 482, lane: 'snare' })]
+    const { entries, changed } = snapAll(notes, 120, (n) => `${n.lane}|${n.tick}`)
+    expect(changed).toBe(true)
+    expect(entries[0].tick).toBe(480)
+  })
+
+  it('leaves genuinely off-grid notes untouched when within tolerance limits', () => {
+    // gridTicks 120, tolerance 25% = 30 ticks. A note at 540 is 60 ticks from
+    // either line (a real 1/8-label offbeat) and must NOT be dragged.
+    const gridTicks = gridTicksForDivision(4)
+    const tolerance = gridTicks * SNAP_TO_GRID_TOLERANCE_FRACTION
+    const notes = [mkNote({ tick: 540, lane: 'snare' })]
+    const { entries, changed } = snapAll(notes, gridTicks, (n) => `${n.lane}|${n.tick}`, tolerance)
+    expect(changed).toBe(false)
+    expect(entries[0].tick).toBe(540)
+  })
+
+  it('snaps a near-grid note but leaves a far one within the same pass', () => {
+    const gridTicks = gridTicksForDivision(4)
+    const tolerance = gridTicks * SNAP_TO_GRID_TOLERANCE_FRACTION
+    const notes = [
+      mkNote({ tick: 485, lane: 'snare' }), // 5 off -> snaps to 480
+      mkNote({ tick: 540, lane: 'yellowTom' }) // 60 off -> stays
+    ]
+    const { entries } = snapAll(notes, gridTicks, (n) => `${n.lane}|${n.tick}`, tolerance)
+    const snare = entries.find((n) => n.lane === 'snare')!
+    const tom = entries.find((n) => n.lane === 'yellowTom')!
+    expect(snare.tick).toBe(480)
+    expect(tom.tick).toBe(540)
+  })
+
+  it('de-duplicates notes that collapse onto the same position (issue #22)', () => {
+    // Two snare notes near tick 480 collapse onto 480 and must merge into one.
+    const notes = [
+      mkNote({ tick: 478, lane: 'snare', duration: 0 }),
+      mkNote({ tick: 482, lane: 'snare', duration: 0 })
+    ]
+    const { entries, changed } = snapAll(notes, 120, (n) => `${n.lane}|${n.tick}`)
+    expect(changed).toBe(true)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].tick).toBe(480)
+  })
+
+  it('keeps the longest sustain when collapsing duplicates', () => {
+    const notes = [
+      mkNote({ tick: 478, lane: 'snare', duration: 30 }),
+      mkNote({ tick: 482, lane: 'snare', duration: 200 })
+    ]
+    const { entries } = snapAll(notes, 120, (n) => `${n.lane}|${n.tick}`)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].duration).toBeGreaterThanOrEqual(200)
+  })
+
+  it('does not merge notes on different lanes at the same tick (chords survive)', () => {
+    const notes = [
+      mkNote({ tick: 482, lane: 'snare' }),
+      mkNote({ tick: 482, lane: 'yellowTom' })
+    ]
+    const { entries } = snapAll(notes, 120, (n) => `${n.lane}|${n.tick}`)
+    expect(entries).toHaveLength(2)
+    expect(entries.every((n) => n.tick === 480)).toBe(true)
+  })
+
+  it('re-aligns sustain ends so durations stay clean', () => {
+    const notes = [mkNote({ tick: 482, lane: 'green', duration: 236 })] // ends at 718
+    const { entries } = snapAll(notes, 120, (n) => `${n.lane}|${n.tick}`)
+    expect(entries[0].tick).toBe(480)
+    // 718 -> nearest 120 grid line is 720, so duration becomes 240.
+    expect(entries[0].duration).toBe(240)
+  })
+
+  it('only snaps eligible (selected) entries', () => {
+    const notes = [
+      mkNote({ tick: 482, lane: 'snare', id: 'sel' }),
+      mkNote({ tick: 482, lane: 'snare', id: 'other' })
+    ]
+    const selected = new Set(['sel'])
+    const { entries } = snapEntriesToGrid(notes, {
+      gridTicks: 120,
+      toleranceTicks: Infinity,
+      isEligible: (n) => selected.has(n.id),
+      keyOf: (n) => `${n.lane}|${n.tick}`
+    })
+    const sel = entries.find((n) => n.id === 'sel')!
+    const other = entries.find((n) => n.id === 'other')!
+    expect(sel.tick).toBe(480)
+    expect(other.tick).toBe(482)
+  })
+
+  it('reports no change when nothing needs snapping', () => {
+    const notes = [mkNote({ tick: 480, lane: 'snare' })]
+    const { entries, changed } = snapAll(notes, 120, (n) => `${n.lane}|${n.tick}`)
+    expect(changed).toBe(false)
+    expect(entries).toBe(notes)
+  })
+})

--- a/src/renderer/src/utils/snapToGrid.ts
+++ b/src/renderer/src/utils/snapToGrid.ts
@@ -1,0 +1,101 @@
+import { TICKS_PER_BEAT } from '../types'
+
+/**
+ * Snapping fraction used by the manual "Snap to Grid" action: a note is only
+ * pulled onto a grid line when it already lies within this fraction of the grid
+ * spacing of that line. Notes nearer the middle of a cell (a genuine finer
+ * subdivision — syncopation, fills, or an intentional off-beat hit) are left
+ * exactly where they are. This mirrors the auto-chart drum-snap behaviour
+ * ("nudge onset jitter onto the grid, leave genuinely off-grid hits untouched")
+ * and fixes issue #22, where coarse snapping dragged correctly-placed notes off
+ * their subdivision.
+ */
+export const SNAP_TO_GRID_TOLERANCE_FRACTION = 0.25
+
+/** Snap a single tick value to the nearest grid line of the given spacing. */
+export function snapTickToGrid(tick: number, gridTicks: number): number {
+  if (gridTicks <= 0) return tick
+  return Math.round(tick / gridTicks) * gridTicks
+}
+
+/** Grid-line spacing in ticks for a snap division (e.g. 4 → 120 ticks at 480 PPQ). */
+export function gridTicksForDivision(division: number): number {
+  return TICKS_PER_BEAT / division
+}
+
+export interface SnapEntriesOptions<T> {
+  /** Spacing between grid lines, in ticks. */
+  gridTicks: number
+  /**
+   * A note is only moved when its distance to the nearest grid line is `<=` this
+   * many ticks. Pass `Infinity` to snap every eligible note to its nearest line.
+   */
+  toleranceTicks: number
+  /** Whether an entry is eligible to be snapped (e.g. a selection filter). */
+  isEligible: (entry: T) => boolean
+  /**
+   * De-duplication key for an entry at its (possibly snapped) position. When two
+   * entries share a key, only the one with the longest sustain is kept, so
+   * snapping never silently stacks notes on top of each other (issue #22).
+   */
+  keyOf: (entry: T) => string
+}
+
+export interface SnapEntriesResult<T> {
+  entries: T[]
+  changed: boolean
+}
+
+/**
+ * Snap a list of tick-based entries onto the grid and collapse any entries that
+ * land on the same logical position.
+ *
+ * Eligible entries within `toleranceTicks` of a grid line are nudged onto it
+ * (their sustain end is re-aligned too, so durations stay clean); entries that
+ * are further out, ineligible, or already on the grid keep their exact tick.
+ * After snapping, entries that now share a `keyOf` value are de-duplicated,
+ * keeping the longest sustain. The returned list preserves first-seen order.
+ */
+export function snapEntriesToGrid<T extends { tick: number; duration: number }>(
+  entries: T[],
+  options: SnapEntriesOptions<T>
+): SnapEntriesResult<T> {
+  const { gridTicks, toleranceTicks, isEligible, keyOf } = options
+  if (gridTicks <= 0) return { entries, changed: false }
+
+  let changed = false
+
+  const snapped = entries.map((entry) => {
+    if (!isEligible(entry)) return entry
+    const newTick = snapTickToGrid(entry.tick, gridTicks)
+    const delta = newTick - entry.tick
+    if (delta === 0 || Math.abs(delta) > toleranceTicks) return entry
+
+    let newDuration = entry.duration
+    if (entry.duration > 0) {
+      newDuration = Math.max(0, snapTickToGrid(entry.tick + entry.duration, gridTicks) - newTick)
+    }
+    if (newTick === entry.tick && newDuration === entry.duration) return entry
+
+    changed = true
+    return { ...entry, tick: newTick, duration: newDuration }
+  })
+
+  // Collapse entries that now share a position, keeping the longest sustain.
+  const byKey = new Map<string, T>()
+  const order: string[] = []
+  for (const entry of snapped) {
+    const key = keyOf(entry)
+    const existing = byKey.get(key)
+    if (!existing) {
+      byKey.set(key, entry)
+      order.push(key)
+    } else {
+      if (entry.duration > existing.duration) byKey.set(key, entry)
+      changed = true
+    }
+  }
+
+  if (!changed) return { entries, changed: false }
+  return { entries: order.map((key) => byKey.get(key)!), changed: true }
+}


### PR DESCRIPTION
Fixes #22.

## Problem
`Snap to Grid` rounded **every** note to the nearest grid line with no tolerance and no overlap handling. As a result:
- Correctly-placed finer-subdivision notes (off-beats, syncopation) were dragged onto coarser beats — "it moves many notes that don't need to be moved".
- Multiple notes collapsed onto the same tick/lane, creating overlapping/duplicate notes that the validator flags and that disappear in game.
- A fine division (e.g. 1/32) barely moved anything useful, so users were forced to a coarse division that over-moved and destroyed notes.

## Fix
- **Tolerance window** — a note is only nudged when it already lies within a fraction of the grid spacing (default 25%) of a grid line. Genuinely off-grid hits are left untouched, mirroring the existing auto-chart drum-snap philosophy.
- **De-duplication** — notes that collapse onto the same `instrument|difficulty|lane|tick` (or vocal `part|tick`) are merged, keeping the longest sustain, so snapping never silently stacks/destroys notes.
- Extracted the logic into a pure, tested `snapEntriesToGrid` util (`src/renderer/src/utils/snapToGrid.ts`).

## Testing
- 12 new unit tests in `snapToGrid.test.ts` (nudge near-grid, leave off-grid, dedupe, keep longest sustain, preserve chords, sustain-end alignment, selection scope).
- Full suite: 30 tests pass. `typecheck` clean.
