### PR TITLE
Release: merge beta into master (validation, explorer refresh, snap-to-grid fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [beta, master]
+  push:
+    branches: [beta, master]
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      # Skip postinstall (electron-builder install-app-deps) — native rebuilds
+      # are not needed for typecheck or the Vitest suite.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,14 +15,21 @@ npm run dev
 
 ## Making Changes
 
-1. Fork the repository and create a branch from `master`
+> **All pull requests target the `beta` branch**, not `master`. `beta` is the
+> integration branch where changes are verified before being merged into
+> `master` for a stable release (see [Releases & Beta Testing](#releases--beta-testing)).
+
+1. Fork the repository and create a branch from `beta`
 2. Make your changes
 3. Run `npm run typecheck` and `npm run lint` to verify
 4. Commit with a descriptive message using [conventional commits](https://www.conventionalcommits.org/):
    - `feat: add pro keys velocity editing` — new feature (bumps minor version)
    - `fix: correct sustain threshold for .chart files` — bug fix (bumps patch version)
    - `refactor:`, `docs:`, `chore:` — non-release changes
-5. Open a pull request against `master`
+5. Open a pull request against `beta`
+
+CI runs `typecheck` and the test suite on every pull request; these checks must
+pass before a PR can be merged into `beta`.
 
 ## Code Style
 
@@ -83,7 +90,8 @@ it ships — no manual reinstall.
 
 ### Typical fix-verification flow
 
-1. Land the fix on the `beta` branch (`git push origin beta`).
+1. Open a pull request with the fix against `beta`. Once CI passes and it's
+   merged, the fix lands on `beta`.
 2. The beta workflow auto-versions `vX.Y.Z-beta.N`, builds all platforms, and
    publishes a GitHub **pre-release**.
 3. Affected users enable the beta toggle (or download the pre-release installer

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import eslintPluginReactHooks from 'eslint-plugin-react-hooks'
 import eslintPluginReactRefresh from 'eslint-plugin-react-refresh'
 
 export default defineConfig(
-  { ignores: ['**/node_modules', '**/dist', '**/out'] },
+  { ignores: ['**/node_modules', '**/dist', '**/out', '**/venv', 'venv/**'] },
   tseslint.configs.recommended,
   eslintPluginReact.configs.flat.recommended,
   eslintPluginReact.configs.flat['jsx-runtime'],

--- a/src/renderer/src/components/MidiEditor.tsx
+++ b/src/renderer/src/components/MidiEditor.tsx
@@ -3812,8 +3812,8 @@ export function MidiEditor(): React.JSX.Element {
           className="midi-snap-to-grid-button"
           title={
             selectedNoteIds.length > 0
-              ? `Snap ${selectedNoteIds.length} selected note(s) to the 1/${snapDivision} grid`
-              : `Snap ALL notes to the 1/${snapDivision} grid`
+              ? `Nudge ${selectedNoteIds.length} selected note(s) that sit just off the 1/${snapDivision} grid onto it (off-grid notes are left alone)`
+              : `Nudge notes that sit just off the 1/${snapDivision} grid onto it (off-grid notes are left alone)`
           }
           onClick={() => songStore?.getState().snapNotesToGrid()}
         >

--- a/src/renderer/src/components/MidiEditor.tsx
+++ b/src/renderer/src/components/MidiEditor.tsx
@@ -1,4 +1,4 @@
-﻿// MIDI Editor - Piano roll style note editor
+// MIDI Editor - Piano roll style note editor
 import { useRef, useEffect, useLayoutEffect, useState, useCallback, useMemo } from 'react'
 import { useProjectStore, getSongStore, useSettingsStore, useUIStore } from '../stores'
 import type { Note, NoteFlags, NoteModifiers, Instrument, DrumLane, GuitarLane, Difficulty, EditingTool, StarPowerPhrase, SoloSection, LaneMarker, LaneMarkerType, VocalNote, VocalPhrase, HarmonyPart,TempoEvent } from '../types'
@@ -406,6 +406,7 @@ function StarPowerLane({
   instrument,
   scrollX,
   zoomLevel,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   width: _width,
   selectedSpId,
   songStore,
@@ -643,6 +644,7 @@ function SoloLane({
   instrument,
   scrollX,
   zoomLevel,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   width: _width,
   selectedSoloId,
   songStore,
@@ -997,12 +999,14 @@ function Notes({
   height,
   selectedNoteIds,
   onNoteClick,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onNoteMove: _onNoteMove,
   starPowerPhrases,
   instrument,
   onFretChange,
   onSustainResize,
-  sustainThreshold
+  sustainThreshold,
+  difficulty
 }: {
   notes: Note[]
   lanes: string[]
@@ -1019,10 +1023,22 @@ function Notes({
   onFretChange?: (noteId: string, fret: number) => void
   onSustainResize?: (noteId: string, e: React.MouseEvent) => void
   sustainThreshold: number
+  difficulty: Difficulty
 }): React.JSX.Element {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const pixelsPerTick = MIDI_EDITOR_CONFIG.pixelsPerTick * zoomLevel
   const isProGuitarInst = instrument === 'proGuitar' || instrument === 'proBass'
+
+  const validationIssues = useUIStore((s) => s.validationIssues)
+  const activeIssues = useMemo(() => {
+    if (!validationIssues) return []
+    return validationIssues.filter(
+      (issue) =>
+        issue.tick !== undefined &&
+        issue.instrument === instrument &&
+        issue.difficulty === difficulty
+    )
+  }, [validationIssues, instrument, difficulty])
 
   // Inline fret editing state (like vocal lyric editing)
   const [editingFret, setEditingFret] = useState<{
@@ -1079,7 +1095,7 @@ function Notes({
 
     const w = canvas.clientWidth
     const h = canvas.clientHeight
-    if (w === 0 || h === 0) return // not laid out yet â€” ResizeObserver will trigger redraw
+    if (w === 0 || h === 0) return // not laid out yet — ResizeObserver will trigger redraw
     if (canvas.width !== w || canvas.height !== h) { canvas.width = w; canvas.height = h }
     else ctx.clearRect(0, 0, w, h)
 
@@ -1103,12 +1119,48 @@ function Notes({
       ctx.stroke()
     }
 
+    // Draw validation issue columns
+    if (activeIssues && activeIssues.length > 0) {
+      for (const issue of activeIssues) {
+        if (issue.tick === undefined) continue
+        const issueX = issue.tick * pixelsPerTick - scrollX
+        if (issueX < 0 || issueX > w) continue
+        
+        // 1. Draw glowing column gradient
+        const colW = 24
+        const startX = issueX - colW / 2
+        const colorBase = issue.severity === 'error' ? '255, 77, 77' : '255, 165, 2'
+        const grad = ctx.createLinearGradient(startX, 0, startX + colW, 0)
+        grad.addColorStop(0, `rgba(${colorBase}, 0)`)
+        grad.addColorStop(0.5, `rgba(${colorBase}, 0.12)`)
+        grad.addColorStop(1, `rgba(${colorBase}, 0)`)
+        ctx.fillStyle = grad
+        ctx.fillRect(startX, 0, colW, totalLaneHeight)
+        
+        // 2. Draw dashed line
+        ctx.strokeStyle = issue.severity === 'error' ? 'rgba(255, 77, 77, 0.6)' : 'rgba(255, 165, 2, 0.6)'
+        ctx.lineWidth = 1.5
+        ctx.setLineDash([4, 4])
+        ctx.beginPath()
+        ctx.moveTo(issueX, 0)
+        ctx.lineTo(issueX, totalLaneHeight)
+        ctx.stroke()
+        ctx.setLineDash([]) // reset dash
+      }
+    }
+
     const selectedSet = new Set(selectedNoteIds)
     const isProGuitarInst = instrument === 'proGuitar' || instrument === 'proBass'
 
     for (const { note, x, y, w, h, isSustain } of visibleNotes) {
       const isSelected = selectedSet.has(note.id)
       const color = MIDI_EDITOR_CONFIG.laneColors[getEditorLaneForNote(note)] || '#888888'
+
+      const noteIssue = activeIssues?.find((issue) => issue.tick === note.tick)
+      if (noteIssue) {
+        ctx.shadowColor = noteIssue.severity === 'error' ? '#ff4d4d' : '#ffa502'
+        ctx.shadowBlur = 12
+      }
 
       if (isSustain) {
         // Sustain: gem head + thinner tail
@@ -1118,15 +1170,32 @@ function Notes({
         // Draw sustain tail
         ctx.fillStyle = color
         ctx.globalAlpha = isSelected ? 0.7 : 0.5
+        // Temporarily disable shadow for the tail
+        if (noteIssue) {
+          ctx.shadowColor = 'transparent'
+          ctx.shadowBlur = 0
+        }
         ctx.beginPath()
         ctx.roundRect(x + STRUM_GEM_WIDTH / 2, tailY, w - STRUM_GEM_WIDTH / 2, tailH, 2)
         ctx.fill()
 
+        // Enable shadow for the gem head
+        if (noteIssue) {
+          ctx.shadowColor = noteIssue.severity === 'error' ? '#ff4d4d' : '#ffa502'
+          ctx.shadowBlur = 12
+        }
         // Draw gem head (full height)
+        ctx.fillStyle = color
         ctx.globalAlpha = isSelected ? 1.0 : 0.85
         ctx.beginPath()
         ctx.roundRect(x, y, STRUM_GEM_WIDTH, h, 3)
         ctx.fill()
+
+        // Reset shadow
+        if (noteIssue) {
+          ctx.shadowColor = 'transparent'
+          ctx.shadowBlur = 0
+        }
 
         // Sustain end handle (subtle line)
         ctx.fillStyle = isSelected ? '#FFFFFF' : color
@@ -1143,6 +1212,11 @@ function Notes({
 
       // Selection outline
       if (isSelected) {
+        // Temporarily disable shadow for the outline
+        if (noteIssue) {
+          ctx.shadowColor = 'transparent'
+          ctx.shadowBlur = 0
+        }
         ctx.strokeStyle = '#FFFFFF'
         ctx.lineWidth = 2
         ctx.beginPath()
@@ -1157,6 +1231,11 @@ function Notes({
 
       // Draw fret number for pro guitar/bass
       if (isProGuitarInst && note.fret !== undefined) {
+        // Temporarily disable shadow for the text
+        if (noteIssue) {
+          ctx.shadowColor = 'transparent'
+          ctx.shadowBlur = 0
+        }
         ctx.globalAlpha = 1.0
         ctx.fillStyle = '#000'
         ctx.font = 'bold 10px monospace'
@@ -1165,9 +1244,15 @@ function Notes({
         ctx.fillText(String(note.fret), x + Math.min(w, STRUM_GEM_WIDTH) / 2, y + h / 2)
       }
 
+      // Final shadow reset per note
+      if (noteIssue) {
+        ctx.shadowColor = 'transparent'
+        ctx.shadowBlur = 0
+      }
+
       ctx.globalAlpha = 1.0
     }
-  }, [visibleNotes, selectedNoteIds, width, height, starPowerPhrases, instrument, pixelsPerTick, scrollX, lanes, rowHeight])
+  }, [visibleNotes, selectedNoteIds, width, height, starPowerPhrases, instrument, pixelsPerTick, scrollX, lanes, rowHeight, activeIssues])
 
   // Handle mousedown: intercept sustain right-edge drags before click propagates
   const handleMouseDown = useCallback(
@@ -2275,7 +2360,9 @@ function SwapLanesTool({
 
   useEffect(() => {
     const next = SWAP_LANE_OPTIONS[instrument]
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (!next.includes(laneA)) setLaneA(next[1] ?? next[0] ?? '')
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (!next.includes(laneB)) setLaneB(next[2] ?? next[0] ?? '')
   }, [instrument, laneA, laneB])
 
@@ -2585,6 +2672,7 @@ export function MidiEditor(): React.JSX.Element {
   // Derive effective scrollX: during playback, compute directly from currentTick
   // to avoid double re-render (tick change â†’ effect â†’ setScrollX â†’ second render)
   const effectiveScrollX = useMemo(() => {
+    // eslint-disable-next-line react-hooks/refs
     if (isPlaying && !isUserScrolling.current) {
       // During playback: keep playhead at ~1/3 from left
       const pixelsPerTick = MIDI_EDITOR_CONFIG.pixelsPerTick * zoomLevel
@@ -3065,7 +3153,7 @@ export function MidiEditor(): React.JSX.Element {
           else finalLane = 'open'
         }
         const shiftPlace = !!e.shiftKey
-        let finalFlags = { ...(flags || {}) }
+        const finalFlags = { ...(flags || {}) }
         if (instrument === 'drums') {
           const clickedDoubleKickLane = lane === DOUBLE_KICK_EDITOR_LANE
           const clickedKickLane = lane === 'kick'
@@ -4171,6 +4259,7 @@ export function MidiEditor(): React.JSX.Element {
                           onFretChange={(noteId, fret) => songStore?.getState().updateNote(noteId, { fret })}
                           onSustainResize={(noteId, e) => handleSustainResize(noteId, e, instrument, lanes as string[])}
                           sustainThreshold={sustainThreshold}
+                          difficulty={activeDifficulty}
                         />
                       )}
                       {selectionBox && selectionBox.instrument === instrument && (

--- a/src/renderer/src/components/ProjectExplorer.css
+++ b/src/renderer/src/components/ProjectExplorer.css
@@ -376,7 +376,7 @@
 
 .explorer-refresh-button {
   padding: 4px;
-  border-radius: 4px;
+  border-radius: 50%;
   opacity: 0.7;
   display: flex;
   align-items: center;

--- a/src/renderer/src/components/ProjectExplorer.css
+++ b/src/renderer/src/components/ProjectExplorer.css
@@ -374,21 +374,17 @@
   cursor: not-allowed;
 }
 
-.explorer-refresh-button {
-  padding: 4px;
-  border-radius: 50%;
+.icon-button.explorer-refresh-button {
+  border-radius: 50% !important;
   opacity: 0.7;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
-.explorer-refresh-button:hover:not(:disabled) {
+.icon-button.explorer-refresh-button:hover:not(:disabled) {
   opacity: 1;
   background-color: rgba(255, 255, 255, 0.08);
 }
 
-.explorer-refresh-button.spinning {
+.icon-button.explorer-refresh-button.spinning {
   animation: spin 1s linear infinite;
   opacity: 0.5;
   cursor: not-allowed;

--- a/src/renderer/src/components/ProjectExplorer.css
+++ b/src/renderer/src/components/ProjectExplorer.css
@@ -373,3 +373,32 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+.explorer-refresh-button {
+  padding: 4px;
+  border-radius: 4px;
+  opacity: 0.7;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.explorer-refresh-button:hover:not(:disabled) {
+  opacity: 1;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.explorer-refresh-button.spinning {
+  animation: spin 1s linear infinite;
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/renderer/src/components/ProjectExplorer.tsx
+++ b/src/renderer/src/components/ProjectExplorer.tsx
@@ -29,6 +29,7 @@ function useAlbumArt(folderPath: string): string | null {
   useEffect(() => {
     // Check cache first
     if (albumArtCache.has(folderPath)) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setArtUrl(albumArtCache.get(folderPath) ?? null)
       return
     }
@@ -130,6 +131,7 @@ export function ProjectExplorer(): React.JSX.Element {
   const [newSongName, setNewSongName] = useState('')
   const [newSongAudioPath, setNewSongAudioPath] = useState<string | null>(null)
   // For future folder tree expansion feature
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [_expandedFolders, _setExpandedFolders] = useState<Set<string>>(new Set())
 
   // Load a folder's songs (shared between initial load and handleOpenFolder)
@@ -426,6 +428,11 @@ export function ProjectExplorer(): React.JSX.Element {
         return
       }
 
+      // Clean up existing song stores
+      for (const id of songIds) {
+        removeSongStore(id)
+      }
+
       // 2. Save as last opened folder
       updateSettings({ lastOpenedFolder: folderPath })
 
@@ -433,6 +440,24 @@ export function ProjectExplorer(): React.JSX.Element {
       await loadFolder(folderPath)
     } catch (error) {
       console.error('Failed to open folder:', error)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleRefresh = async (): Promise<void> => {
+    if (!loadedFolderPath) return
+    try {
+      setIsLoading(true)
+
+      // Clean up existing song stores
+      for (const id of songIds) {
+        removeSongStore(id)
+      }
+
+      await loadFolder(loadedFolderPath)
+    } catch (error) {
+      console.error('Failed to refresh folder:', error)
     } finally {
       setIsLoading(false)
     }
@@ -578,10 +603,21 @@ export function ProjectExplorer(): React.JSX.Element {
           <>
             {/* Folder path display */}
             <div className="explorer-folder-path" title={loadedFolderPath}>
-              <span className="folder-icon">📂</span>
-              <span className="folder-name">
-                {loadedFolderPath.split(/[\\/]/).pop() || loadedFolderPath}
-              </span>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>
+                <span className="folder-icon">📂</span>
+                <span className="folder-name">
+                  {loadedFolderPath.split(/[\\/]/).pop() || loadedFolderPath}
+                </span>
+              </div>
+              <button
+                className={`icon-button explorer-refresh-button ${isLoading ? 'spinning' : ''}`}
+                onClick={handleRefresh}
+                title="Refresh Folder"
+                disabled={isLoading}
+                style={{ marginLeft: 'auto', flexShrink: 0 }}
+              >
+                🔄
+              </button>
             </div>
 
             {/* Song list */}

--- a/src/renderer/src/components/ProjectExplorer.tsx
+++ b/src/renderer/src/components/ProjectExplorer.tsx
@@ -616,7 +616,17 @@ export function ProjectExplorer(): React.JSX.Element {
                 disabled={isLoading}
                 style={{ marginLeft: 'auto', flexShrink: 0 }}
               >
-                🔄
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  style={{ width: '14px', height: '14px' }}
+                >
+                  <path
+                    d="M17.65 6.35A7.958 7.958 0 0 0 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0 1 12 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                    fill="currentColor"
+                  />
+                </svg>
               </button>
             </div>
 

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -21,6 +21,17 @@ export function SettingsModal(): React.JSX.Element | null {
   const betaUpdates = useSettingsStore((s) => s.betaUpdates)
   const invertPianoRollVerticalScroll = useSettingsStore((s) => s.invertPianoRollVerticalScroll)
   const updateSettings = useSettingsStore((s) => s.updateSettings)
+
+  const validationMinSustainGuitar = useSettingsStore((s) => s.validationMinSustainGuitar)
+  const validationMinSustainBass = useSettingsStore((s) => s.validationMinSustainBass)
+  const validationMinSustainKeys = useSettingsStore((s) => s.validationMinSustainKeys)
+  const validationMinSustainDrums = useSettingsStore((s) => s.validationMinSustainDrums)
+  const validationEnableOverlapsCheck = useSettingsStore((s) => s.validationEnableOverlapsCheck)
+  const validationEnableStarPowerCheck = useSettingsStore((s) => s.validationEnableStarPowerCheck)
+  const validationEnableDrumImpossibilityCheck = useSettingsStore((s) => s.validationEnableDrumImpossibilityCheck)
+  const validationDrumTimeThresholdMs = useSettingsStore((s) => s.validationDrumTimeThresholdMs)
+  const validationDrumCrossoverThresholdMs = useSettingsStore((s) => s.validationDrumCrossoverThresholdMs)
+
   const [recordingAction, setRecordingAction] = useState<HotkeyAction | null>(null)
   const [draftHotkeys, setDraftHotkeys] = useState<AppHotkeys>(hotkeys)
   const [draftEnableAutoChart, setDraftEnableAutoChart] = useState(enableAutoChart)
@@ -28,16 +39,42 @@ export function SettingsModal(): React.JSX.Element | null {
   const [draftBetaUpdates, setDraftBetaUpdates] = useState(betaUpdates)
   const [draftInvertPianoRollVerticalScroll, setDraftInvertPianoRollVerticalScroll] = useState(invertPianoRollVerticalScroll)
 
+  const [draftValidationMinSustainGuitar, setDraftValidationMinSustainGuitar] = useState(validationMinSustainGuitar)
+  const [draftValidationMinSustainBass, setDraftValidationMinSustainBass] = useState(validationMinSustainBass)
+  const [draftValidationMinSustainKeys, setDraftValidationMinSustainKeys] = useState(validationMinSustainKeys)
+  const [draftValidationMinSustainDrums, setDraftValidationMinSustainDrums] = useState(validationMinSustainDrums)
+  const [draftValidationEnableOverlapsCheck, setDraftValidationEnableOverlapsCheck] = useState(validationEnableOverlapsCheck)
+  const [draftValidationEnableStarPowerCheck, setDraftValidationEnableStarPowerCheck] = useState(validationEnableStarPowerCheck)
+  const [draftValidationEnableDrumImpossibilityCheck, setDraftValidationEnableDrumImpossibilityCheck] = useState(validationEnableDrumImpossibilityCheck)
+  const [draftValidationDrumTimeThresholdMs, setDraftValidationDrumTimeThresholdMs] = useState(validationDrumTimeThresholdMs)
+  const [draftValidationDrumCrossoverThresholdMs, setDraftValidationDrumCrossoverThresholdMs] = useState(validationDrumCrossoverThresholdMs)
+
   useEffect(() => {
     if (isOpen) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDraftHotkeys(hotkeys)
       setDraftEnableAutoChart(enableAutoChart)
       setDraftAutoChartOutputDir(autoChartOutputDir ?? '')
       setDraftBetaUpdates(betaUpdates)
       setDraftInvertPianoRollVerticalScroll(invertPianoRollVerticalScroll)
       setRecordingAction(null)
+
+      setDraftValidationMinSustainGuitar(validationMinSustainGuitar)
+      setDraftValidationMinSustainBass(validationMinSustainBass)
+      setDraftValidationMinSustainKeys(validationMinSustainKeys)
+      setDraftValidationMinSustainDrums(validationMinSustainDrums)
+      setDraftValidationEnableOverlapsCheck(validationEnableOverlapsCheck)
+      setDraftValidationEnableStarPowerCheck(validationEnableStarPowerCheck)
+      setDraftValidationEnableDrumImpossibilityCheck(validationEnableDrumImpossibilityCheck)
+      setDraftValidationDrumTimeThresholdMs(validationDrumTimeThresholdMs)
+      setDraftValidationDrumCrossoverThresholdMs(validationDrumCrossoverThresholdMs)
     }
-  }, [autoChartOutputDir, enableAutoChart, betaUpdates, hotkeys, invertPianoRollVerticalScroll, isOpen])
+  }, [
+    autoChartOutputDir, enableAutoChart, betaUpdates, hotkeys, invertPianoRollVerticalScroll, isOpen,
+    validationMinSustainGuitar, validationMinSustainBass, validationMinSustainKeys, validationMinSustainDrums,
+    validationEnableOverlapsCheck, validationEnableStarPowerCheck, validationEnableDrumImpossibilityCheck,
+    validationDrumTimeThresholdMs, validationDrumCrossoverThresholdMs
+  ])
 
   useEffect(() => {
     if (!isOpen || draftAutoChartOutputDir.trim()) return
@@ -185,6 +222,98 @@ export function SettingsModal(): React.JSX.Element | null {
               </label>
             </div>
           </section>
+          <section className="settings-preferences-group">
+            <h3 className="settings-hotkey-group-title">Validation Preferences</h3>
+            <div className="settings-preferences-body">
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px' }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                  <label className="settings-checkbox-row">
+                    <input
+                      type="checkbox"
+                      checked={draftValidationEnableOverlapsCheck}
+                      onChange={(event) => setDraftValidationEnableOverlapsCheck(event.target.checked)}
+                    />
+                    <span>Enable overlapping notes check</span>
+                  </label>
+                  <label className="settings-checkbox-row">
+                    <input
+                      type="checkbox"
+                      checked={draftValidationEnableStarPowerCheck}
+                      onChange={(event) => setDraftValidationEnableStarPowerCheck(event.target.checked)}
+                    />
+                    <span>Enable missing star power check</span>
+                  </label>
+                  <label className="settings-checkbox-row">
+                    <input
+                      type="checkbox"
+                      checked={draftValidationEnableDrumImpossibilityCheck}
+                      onChange={(event) => setDraftValidationEnableDrumImpossibilityCheck(event.target.checked)}
+                    />
+                    <span>Enable drum physical checks</span>
+                  </label>
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <span style={{ fontSize: '13px', color: '#ccc' }}>Guitar min sustain (ticks)</span>
+                    <input
+                      type="number"
+                      style={{ width: '70px', padding: '4px', background: '#2e2e3e', border: '1px solid #444', color: '#fff', borderRadius: '4px' }}
+                      value={draftValidationMinSustainGuitar}
+                      onChange={(e) => setDraftValidationMinSustainGuitar(parseInt(e.target.value, 10) || 0)}
+                    />
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <span style={{ fontSize: '13px', color: '#ccc' }}>Bass min sustain (ticks)</span>
+                    <input
+                      type="number"
+                      style={{ width: '70px', padding: '4px', background: '#2e2e3e', border: '1px solid #444', color: '#fff', borderRadius: '4px' }}
+                      value={draftValidationMinSustainBass}
+                      onChange={(e) => setDraftValidationMinSustainBass(parseInt(e.target.value, 10) || 0)}
+                    />
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <span style={{ fontSize: '13px', color: '#ccc' }}>Keys min sustain (ticks)</span>
+                    <input
+                      type="number"
+                      style={{ width: '70px', padding: '4px', background: '#2e2e3e', border: '1px solid #444', color: '#fff', borderRadius: '4px' }}
+                      value={draftValidationMinSustainKeys}
+                      onChange={(e) => setDraftValidationMinSustainKeys(parseInt(e.target.value, 10) || 0)}
+                    />
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <span style={{ fontSize: '13px', color: '#ccc' }}>Drums min sustain (ticks)</span>
+                    <input
+                      type="number"
+                      style={{ width: '70px', padding: '4px', background: '#2e2e3e', border: '1px solid #444', color: '#fff', borderRadius: '4px' }}
+                      value={draftValidationMinSustainDrums}
+                      onChange={(e) => setDraftValidationMinSustainDrums(parseInt(e.target.value, 10) || 0)}
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px', borderTop: '1px solid #333', marginTop: '12px', paddingTop: '12px' }}>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <span style={{ fontSize: '13px', color: '#ccc' }} title="Speed limit between hits on different drum pads/cymbals">Drum separation limit (ms)</span>
+                  <input
+                    type="number"
+                    style={{ width: '70px', padding: '4px', background: '#2e2e3e', border: '1px solid #444', color: '#fff', borderRadius: '4px' }}
+                    value={draftValidationDrumTimeThresholdMs}
+                    onChange={(e) => setDraftValidationDrumTimeThresholdMs(parseInt(e.target.value, 10) || 0)}
+                  />
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <span style={{ fontSize: '13px', color: '#ccc' }} title="Speed limit for crossover hits (e.g. Snare to Green)">Crossover limit (ms)</span>
+                  <input
+                    type="number"
+                    style={{ width: '70px', padding: '4px', background: '#2e2e3e', border: '1px solid #444', color: '#fff', borderRadius: '4px' }}
+                    value={draftValidationDrumCrossoverThresholdMs}
+                    onChange={(e) => setDraftValidationDrumCrossoverThresholdMs(parseInt(e.target.value, 10) || 0)}
+                  />
+                </div>
+              </div>
+            </div>
+          </section>
           {hasConflicts && (
             <div className="settings-hotkey-conflicts-banner">
               Resolve duplicate bindings before saving. Conflicting shortcuts are highlighted below.
@@ -251,7 +380,16 @@ export function SettingsModal(): React.JSX.Element | null {
                 enableAutoChart: draftEnableAutoChart,
                 autoChartOutputDir: draftAutoChartOutputDir.trim() || undefined,
                 betaUpdates: draftBetaUpdates,
-                invertPianoRollVerticalScroll: draftInvertPianoRollVerticalScroll
+                invertPianoRollVerticalScroll: draftInvertPianoRollVerticalScroll,
+                validationMinSustainGuitar: draftValidationMinSustainGuitar,
+                validationMinSustainBass: draftValidationMinSustainBass,
+                validationMinSustainKeys: draftValidationMinSustainKeys,
+                validationMinSustainDrums: draftValidationMinSustainDrums,
+                validationEnableOverlapsCheck: draftValidationEnableOverlapsCheck,
+                validationEnableStarPowerCheck: draftValidationEnableStarPowerCheck,
+                validationEnableDrumImpossibilityCheck: draftValidationEnableDrumImpossibilityCheck,
+                validationDrumTimeThresholdMs: draftValidationDrumTimeThresholdMs,
+                validationDrumCrossoverThresholdMs: draftValidationDrumCrossoverThresholdMs
               })
               if (draftBetaUpdates !== betaUpdates) {
                 void window.api.setUpdateChannel(draftBetaUpdates)

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -3,11 +3,17 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { useProjectStore, useSettingsStore, getSongStore, useUIStore } from '../stores'
 import * as audioService from '../services/audioService'
 import * as playbackController from '../services/playbackController'
-import { parseMidiBase64, parseChartFile, serializeMidiBase64, serializeChartFile } from '../utils/midiParser'
-import { validateChart, type ValidationIssue } from '../utils/chartValidation'
+import {
+  parseMidiBase64,
+  parseChartFile,
+  serializeMidiBase64,
+  serializeChartFile
+} from '../utils/midiParser'
+import { validateChartAsync } from '../utils/chartValidation'
 import type { SongMetadata } from '../types'
 import { SettingsModal } from './SettingsModal'
 import { ExportModal } from './ExportModal'
+import { ValidationPreviewCard } from './ValidationPreviewCard'
 import './Toolbar.css'
 
 type AutoChartProgressState = {
@@ -41,6 +47,8 @@ export function Toolbar(): React.JSX.Element {
   const { activeSongId, setLoadedFolder, addSong, setActiveSong } = useProjectStore()
   const isExportModalOpen = useUIStore((s) => s.isExportModalOpen)
   const setExportModalOpen = useUIStore((s) => s.setExportModalOpen)
+  const validationIssues = useUIStore((s) => s.validationIssues)
+  const setValidationIssues = useUIStore((s) => s.setValidationIssues)
   const {
     autosaveEnabled,
     highwaySpeed,
@@ -56,17 +64,37 @@ export function Toolbar(): React.JSX.Element {
   const [autoChartFolders, setAutoChartFolders] = useState<string[]>([])
   const [autoChartStemFolders, setAutoChartStemFolders] = useState<string[]>([])
   const [autoChartInputTab, setAutoChartInputTab] = useState<'mix' | 'stems'>('mix')
-  const [autoChartFullMixSubTab, setAutoChartFullMixSubTab] = useState<'files' | 'folders' | 'urls'>('files')
+  const [autoChartFullMixSubTab, setAutoChartFullMixSubTab] = useState<
+    'files' | 'folders' | 'urls'
+  >('files')
   type StemSong = {
     id: string
     name: string
-    stems: { drums: string; bass: string; vocals: string; guitar: string; piano: string; vocalsHarm2: string; vocalsHarm3: string; crowd: string }
+    stems: {
+      drums: string
+      bass: string
+      vocals: string
+      guitar: string
+      piano: string
+      vocalsHarm2: string
+      vocalsHarm3: string
+      crowd: string
+    }
     extras: string[]
   }
   const makeEmptyStemSong = (): StemSong => ({
     id: `stem-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     name: '',
-    stems: { drums: '', bass: '', vocals: '', guitar: '', piano: '', vocalsHarm2: '', vocalsHarm3: '', crowd: '' },
+    stems: {
+      drums: '',
+      bass: '',
+      vocals: '',
+      guitar: '',
+      piano: '',
+      vocalsHarm2: '',
+      vocalsHarm3: '',
+      crowd: ''
+    },
     extras: []
   })
   const [autoChartStemSongs, setAutoChartStemSongs] = useState<StemSong[]>([makeEmptyStemSong()])
@@ -82,7 +110,9 @@ export function Toolbar(): React.JSX.Element {
   const [autoChartAdvancedOpen, setAutoChartAdvancedOpen] = useState(false)
   // Optional user-supplied tempo map. Empty = use STRUM's auto-detection.
   // First entry's BPM (sorted by timeSec) overrides initial detected tempo.
-  const [autoChartTempoEvents, setAutoChartTempoEvents] = useState<Array<{ timeSec: string; bpm: string }>>([])
+  const [autoChartTempoEvents, setAutoChartTempoEvents] = useState<
+    Array<{ timeSec: string; bpm: string }>
+  >([])
   const [autoChartEnabledTracks, setAutoChartEnabledTracks] = useState<{
     drums: boolean
     guitar: boolean
@@ -91,7 +121,15 @@ export function Toolbar(): React.JSX.Element {
     harmonies: boolean
     keys: boolean
     proKeys: boolean
-  }>({ drums: true, guitar: true, bass: true, vocals: true, harmonies: true, keys: true, proKeys: true })
+  }>({
+    drums: true,
+    guitar: true,
+    bass: true,
+    vocals: true,
+    harmonies: true,
+    keys: true,
+    proKeys: true
+  })
   const [autoChartCloseCountdown, setAutoChartCloseCountdown] = useState<number | null>(null)
   const [defaultAutoChartOutputDir, setDefaultAutoChartOutputDir] = useState('')
   const [autoChartErrorCopied, setAutoChartErrorCopied] = useState(false)
@@ -159,13 +197,50 @@ export function Toolbar(): React.JSX.Element {
 
   // Reactively subscribe to song store state so UI updates when isPlaying/folderPath changes
   const [isPlaying, setIsPlaying] = useState(false)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [_folderPath, setFolderPath] = useState<string | null>(null)
   const [songName, setSongName] = useState('')
   const [songArtist, setSongArtist] = useState('')
   const [isDirty, setIsDirty] = useState(false)
-  const [validationIssues, setValidationIssues] = useState<ValidationIssue[] | null>(null)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [_snapDivision, setSnapDivision] = useState(4)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [_currentBpm, setCurrentBpm] = useState(120)
+  const [isValidating, setIsValidating] = useState(false)
+
+  const cleanupAllDuplicates = async (): Promise<void> => {
+    if (!activeSongId) return
+    const store = getSongStore(activeSongId)
+    const currentSong = store.getState().song
+    const notes = currentSong.notes || []
+
+    const seen = new Set<string>()
+    const duplicatesToRemove: string[] = []
+
+    for (const note of notes) {
+      const key = `${note.instrument}|${note.difficulty}|${note.lane}|${note.tick}`
+      if (seen.has(key)) {
+        duplicatesToRemove.push(note.id)
+      } else {
+        seen.add(key)
+      }
+    }
+
+    if (duplicatesToRemove.length === 0) return
+
+    for (const id of duplicatesToRemove) {
+      store.getState().deleteNote(id)
+    }
+
+    try {
+      const updatedState = store.getState()
+      const settings = useSettingsStore.getState()
+      const newIssues = await validateChartAsync(updatedState.song, settings)
+      setValidationIssues(newIssues)
+    } catch (err) {
+      console.error('[cleanupAllDuplicates validation failed]', err)
+    }
+  }
 
   useEffect(() => {
     if (!songStore) {
@@ -176,6 +251,8 @@ export function Toolbar(): React.JSX.Element {
       setIsDirty(false)
       return
     }
+
+    let lastValidationId = 0
 
     // Seed on mount
     const s = songStore.getState()
@@ -190,11 +267,32 @@ export function Toolbar(): React.JSX.Element {
     return songStore.subscribe((state, prev) => {
       if (state.isPlaying !== prev.isPlaying) setIsPlaying(state.isPlaying)
       if (state.song.folderPath !== prev.song.folderPath) setFolderPath(state.song.folderPath)
-      if (state.song.metadata.name !== prev.song.metadata.name) setSongName(state.song.metadata.name)
-      if (state.song.metadata.artist !== prev.song.metadata.artist) setSongArtist(state.song.metadata.artist)
+      if (state.song.metadata.name !== prev.song.metadata.name)
+        setSongName(state.song.metadata.name)
+      if (state.song.metadata.artist !== prev.song.metadata.artist)
+        setSongArtist(state.song.metadata.artist)
       if (state.isDirty !== prev.isDirty) setIsDirty(state.isDirty)
       if (state.snapDivision !== prev.snapDivision) setSnapDivision(state.snapDivision)
-      if (state.song.tempoEvents !== prev.song.tempoEvents) setCurrentBpm(state.song.tempoEvents[0]?.bpm ?? 120)
+      if (state.song.tempoEvents !== prev.song.tempoEvents)
+        setCurrentBpm(state.song.tempoEvents[0]?.bpm ?? 120)
+      if (state.song.notes !== prev.song.notes || state.song.vocalNotes !== prev.song.vocalNotes) {
+        const currentIssues = useUIStore.getState().validationIssues
+        if (currentIssues !== null) {
+          const validationId = ++lastValidationId
+          const settings = useSettingsStore.getState()
+          validateChartAsync(state.song, settings)
+            .then((newIssues) => {
+              if (validationId === lastValidationId) {
+                useUIStore.getState().setValidationIssues(newIssues)
+              }
+            })
+            .catch((err) => {
+              if (validationId === lastValidationId) {
+                console.error('[Validation Subscription Error]', err)
+              }
+            })
+        }
+      }
     })
   }, [songStore])
 
@@ -225,7 +323,7 @@ export function Toolbar(): React.JSX.Element {
 
     const newStore = getSongStore(activeSongId)
     const newFolderPath = newStore.getState().song.folderPath
-    
+
     if (!newFolderPath) {
       setIsAudioLoaded(false)
       return
@@ -294,67 +392,80 @@ export function Toolbar(): React.JSX.Element {
     }
   }, [updateSettings])
 
-  const loadProjectFolder = useCallback(async (folderPath: string): Promise<void> => {
-    setLoadedFolder(folderPath)
-    const songFolders = await window.api.scanFolder(folderPath)
+  const loadProjectFolder = useCallback(
+    async (folderPath: string): Promise<void> => {
+      setLoadedFolder(folderPath)
+      const songFolders = await window.api.scanFolder(folderPath)
 
-    for (const songFolder of songFolders) {
-      try {
-        const iniData = await window.api.readSongIni(songFolder.path)
+      for (const songFolder of songFolders) {
+        try {
+          const iniData = await window.api.readSongIni(songFolder.path)
 
-        const metadata: SongMetadata = {
-          ...(iniData ?? {}),
-          name: (iniData?.name as string) || (iniData?.title as string) || songFolder.name,
-          artist: (iniData?.artist as string) || 'Unknown Artist',
-          album: iniData?.album as string,
-          genre: iniData?.genre as string,
-          year: iniData?.year !== undefined ? String(iniData.year) : undefined,
-          charter: iniData?.charter as string,
-          song_length: iniData?.song_length as number,
-          preview_start_time: iniData?.preview_start_time as number
+          const metadata: SongMetadata = {
+            ...(iniData ?? {}),
+            name: (iniData?.name as string) || (iniData?.title as string) || songFolder.name,
+            artist: (iniData?.artist as string) || 'Unknown Artist',
+            album: iniData?.album as string,
+            genre: iniData?.genre as string,
+            year: iniData?.year !== undefined ? String(iniData.year) : undefined,
+            charter: iniData?.charter as string,
+            song_length: iniData?.song_length as number,
+            preview_start_time: iniData?.preview_start_time as number
+          }
+
+          let parsedData: ReturnType<typeof parseMidiBase64> | null = null
+          let sourceFormat: 'midi' | 'chart' = 'midi'
+
+          const midiResult = await window.api.readSongMidi(songFolder.path)
+          if (midiResult) {
+            parsedData =
+              midiResult.type === 'chart'
+                ? parseChartFile(midiResult.data)
+                : parseMidiBase64(midiResult.data)
+            sourceFormat = midiResult.type === 'chart' ? 'chart' : 'midi'
+          }
+
+          const store = getSongStore(songFolder.id)
+          store.getState().loadSong({
+            id: songFolder.id,
+            folderPath: songFolder.path,
+            metadata,
+            notes: parsedData?.notes ?? [],
+            vocalNotes: parsedData?.vocalNotes ?? [],
+            vocalPhrases: parsedData?.vocalPhrases ?? [],
+            starPowerPhrases: parsedData?.starPowerPhrases ?? [],
+            soloSections: parsedData?.soloSections ?? [],
+            laneMarkers: parsedData?.laneMarkers ?? [],
+            songSections: parsedData?.songSections ?? [],
+            tempoEvents: parsedData?.tempoEvents ?? [{ tick: 0, bpm: 120 }],
+            timeSignatures: parsedData?.timeSignatures ?? [
+              { tick: 0, numerator: 4, denominator: 4 }
+            ],
+            videoSync: { clips: [], offsetMs: 0, trimStartMs: 0, trimEndMs: 0 },
+            audioSync: { clips: [] },
+            venueTrack: parsedData?.venueTrack ?? {
+              autoGenerated: false,
+              lighting: [],
+              postProcessing: [],
+              stage: [],
+              performer: [],
+              cameraCuts: []
+            },
+            sourceFormat
+          })
+
+          addSong(songFolder.id)
+        } catch (error) {
+          console.error(`Failed to load song ${songFolder.name}:`, error)
         }
-
-        let parsedData: ReturnType<typeof parseMidiBase64> | null = null
-        let sourceFormat: 'midi' | 'chart' = 'midi'
-
-        const midiResult = await window.api.readSongMidi(songFolder.path)
-        if (midiResult) {
-          parsedData = midiResult.type === 'chart'
-            ? parseChartFile(midiResult.data)
-            : parseMidiBase64(midiResult.data)
-          sourceFormat = midiResult.type === 'chart' ? 'chart' : 'midi'
-        }
-
-        const store = getSongStore(songFolder.id)
-        store.getState().loadSong({
-          id: songFolder.id,
-          folderPath: songFolder.path,
-          metadata,
-          notes: parsedData?.notes ?? [],
-          vocalNotes: parsedData?.vocalNotes ?? [],
-          vocalPhrases: parsedData?.vocalPhrases ?? [],
-          starPowerPhrases: parsedData?.starPowerPhrases ?? [],
-          soloSections: parsedData?.soloSections ?? [],
-          laneMarkers: parsedData?.laneMarkers ?? [],
-          songSections: parsedData?.songSections ?? [],
-          tempoEvents: parsedData?.tempoEvents ?? [{ tick: 0, bpm: 120 }],
-          timeSignatures: parsedData?.timeSignatures ?? [{ tick: 0, numerator: 4, denominator: 4 }],
-          videoSync: { clips: [], offsetMs: 0, trimStartMs: 0, trimEndMs: 0 },
-          audioSync: { clips: [] },
-          venueTrack: parsedData?.venueTrack ?? { autoGenerated: false, lighting: [], postProcessing: [], stage: [], performer: [], cameraCuts: [] },
-          sourceFormat
-        })
-
-        addSong(songFolder.id)
-      } catch (error) {
-        console.error(`Failed to load song ${songFolder.name}:`, error)
       }
-    }
 
-    if (songFolders.length > 0) {
-      setActiveSong(songFolders[0].id)
-    }
-  }, [addSong, setActiveSong, setLoadedFolder])
+      if (songFolders.length > 0) {
+        setActiveSong(songFolders[0].id)
+      }
+    },
+    [addSong, setActiveSong, setLoadedFolder]
+  )
 
   const handleOpenFolder = async (): Promise<void> => {
     try {
@@ -382,9 +493,8 @@ export function Toolbar(): React.JSX.Element {
         }
 
         const incomingPercent = event.percent ?? prev.percent
-        const nextPercent = incomingRank === currentRank
-          ? Math.max(prev.percent, incomingPercent)
-          : incomingPercent
+        const nextPercent =
+          incomingRank === currentRank ? Math.max(prev.percent, incomingPercent) : incomingPercent
 
         return {
           ...prev,
@@ -410,7 +520,9 @@ export function Toolbar(): React.JSX.Element {
           isRunning: false,
           percent: 100,
           stage: 'complete',
-          message: event.success ? 'Auto-chart complete.' : 'Auto-chart finished with no successful songs.',
+          message: event.success
+            ? 'Auto-chart complete.'
+            : 'Auto-chart finished with no successful songs.',
           warnings: event.errors
         }
       })
@@ -486,7 +598,9 @@ export function Toolbar(): React.JSX.Element {
   }, [])
 
   const handleUpdateAutoChartUrl = useCallback((index: number, value: string): void => {
-    setAutoChartUrls((prev) => prev.map((entry, entryIndex) => (entryIndex === index ? value : entry)))
+    setAutoChartUrls((prev) =>
+      prev.map((entry, entryIndex) => (entryIndex === index ? value : entry))
+    )
   }, [])
 
   const handleRemoveAutoChartUrl = useCallback((index: number): void => {
@@ -540,7 +654,10 @@ export function Toolbar(): React.JSX.Element {
     }
 
     if (!outputDir) {
-      setAutoChartProgress((prev) => ({ ...prev, error: 'Choose an output folder before starting.' }))
+      setAutoChartProgress((prev) => ({
+        ...prev,
+        error: 'Choose an output folder before starting.'
+      }))
       return
     }
 
@@ -551,7 +668,10 @@ export function Toolbar(): React.JSX.Element {
       stemSongs.length === 0 &&
       urls.length === 0
     ) {
-      setAutoChartProgress((prev) => ({ ...prev, error: 'Add at least one audio file, folder, URL, or stem song.' }))
+      setAutoChartProgress((prev) => ({
+        ...prev,
+        error: 'Add at least one audio file, folder, URL, or stem song.'
+      }))
       return
     }
 
@@ -562,9 +682,21 @@ export function Toolbar(): React.JSX.Element {
         setAutoChartProgress((prev) => ({ ...prev, error: 'Every stem song needs a name.' }))
         return
       }
-      const hasInstrument = ['drums', 'bass', 'vocals', 'guitar', 'piano', 'vocalsHarm2', 'vocalsHarm3', 'crowd'].some((k) => song.stems[k])
+      const hasInstrument = [
+        'drums',
+        'bass',
+        'vocals',
+        'guitar',
+        'piano',
+        'vocalsHarm2',
+        'vocalsHarm3',
+        'crowd'
+      ].some((k) => song.stems[k])
       if (!hasInstrument && song.extras.length === 0) {
-        setAutoChartProgress((prev) => ({ ...prev, error: `Stem song "${song.name}" has no stems selected.` }))
+        setAutoChartProgress((prev) => ({
+          ...prev,
+          error: `Stem song "${song.name}" has no stems selected.`
+        }))
         return
       }
     }
@@ -602,7 +734,10 @@ export function Toolbar(): React.JSX.Element {
         tempoMap: (() => {
           const parsed = autoChartTempoEvents
             .map((e) => ({ timeSec: parseFloat(e.timeSec), bpm: parseFloat(e.bpm) }))
-            .filter((e) => Number.isFinite(e.timeSec) && Number.isFinite(e.bpm) && e.bpm > 0 && e.timeSec >= 0)
+            .filter(
+              (e) =>
+                Number.isFinite(e.timeSec) && Number.isFinite(e.bpm) && e.bpm > 0 && e.timeSec >= 0
+            )
             .sort((a, b) => a.timeSec - b.timeSec)
           return parsed.length > 0 ? parsed : undefined
         })()
@@ -615,7 +750,23 @@ export function Toolbar(): React.JSX.Element {
         error: error instanceof Error ? error.message : String(error)
       }))
     }
-  }, [autoChartDisableOnlineLookup, autoChartEnabledTracks, autoChartFiles, autoChartFolders, autoChartImproveTempo, autoChartKeepStems, autoChartSnapDrums, autoChartStemFolders, autoChartStemSongs, autoChartProgress.outputDir, autoChartTempoEvents, autoChartManualBpm, autoChartUrls, runtimeStatus, updateSettings])
+  }, [
+    autoChartDisableOnlineLookup,
+    autoChartEnabledTracks,
+    autoChartFiles,
+    autoChartFolders,
+    autoChartImproveTempo,
+    autoChartKeepStems,
+    autoChartSnapDrums,
+    autoChartStemFolders,
+    autoChartStemSongs,
+    autoChartProgress.outputDir,
+    autoChartTempoEvents,
+    autoChartManualBpm,
+    autoChartUrls,
+    runtimeStatus,
+    updateSettings
+  ])
 
   const handleCancelAutoChart = useCallback(async (): Promise<void> => {
     if (!autoChartProgress.runId) return
@@ -684,12 +835,12 @@ export function Toolbar(): React.JSX.Element {
 
       const venueTrack = state.song.venueTrack
       if (
-        venueTrack.autoGenerated
-        || venueTrack.lighting.length > 0
-        || venueTrack.postProcessing.length > 0
-        || venueTrack.stage.length > 0
-        || venueTrack.performer.length > 0
-        || venueTrack.cameraCuts.length > 0
+        venueTrack.autoGenerated ||
+        venueTrack.lighting.length > 0 ||
+        venueTrack.postProcessing.length > 0 ||
+        venueTrack.stage.length > 0 ||
+        venueTrack.performer.length > 0 ||
+        venueTrack.cameraCuts.length > 0
       ) {
         await window.api.writeVenueJson(state.song.folderPath, venueTrack)
       }
@@ -717,7 +868,14 @@ export function Toolbar(): React.JSX.Element {
 
   // Updater state
   type UpdaterStatusState = {
-    state: 'idle' | 'checking' | 'available' | 'downloading' | 'downloaded' | 'not-available' | 'error'
+    state:
+      | 'idle'
+      | 'checking'
+      | 'available'
+      | 'downloading'
+      | 'downloaded'
+      | 'not-available'
+      | 'error'
     version?: string
     percent?: number
     message?: string
@@ -827,7 +985,7 @@ export function Toolbar(): React.JSX.Element {
           className="toolbar-button toolbar-button-play"
           onClick={handlePlayPause}
           disabled={!activeSongId}
-          title={isAudioLoaded ? "Play/Pause (Space)" : "Play/Pause (no audio)"}
+          title={isAudioLoaded ? 'Play/Pause (Space)' : 'Play/Pause (no audio)'}
         >
           <span className="toolbar-icon">{isPlaying ? '⏸' : '▶'}</span>
         </button>
@@ -900,11 +1058,15 @@ export function Toolbar(): React.JSX.Element {
             <span className="toolbar-updater-label">Up to date</span>
           )}
           {updaterStatus.state === 'available' && (
-            <span className="toolbar-updater-label">⬇ Update v{updaterStatus.version} available…</span>
+            <span className="toolbar-updater-label">
+              ⬇ Update v{updaterStatus.version} available…
+            </span>
           )}
           {updaterStatus.state === 'downloading' && (
             <>
-              <span className="toolbar-updater-label">Downloading update {updaterStatus.message ?? ''}</span>
+              <span className="toolbar-updater-label">
+                Downloading update {updaterStatus.message ?? ''}
+              </span>
               <div className="toolbar-updater-bar">
                 <div
                   className="toolbar-updater-bar-fill"
@@ -917,7 +1079,9 @@ export function Toolbar(): React.JSX.Element {
             <span className="toolbar-updater-label">✔ Update ready — see prompt</span>
           )}
           {updaterStatus.state === 'error' && (
-            <span className="toolbar-updater-label" title={updaterStatus.message}>⚠ Update error</span>
+            <span className="toolbar-updater-label" title={updaterStatus.message}>
+              ⚠ Update error
+            </span>
           )}
         </div>
       )}
@@ -935,7 +1099,10 @@ export function Toolbar(): React.JSX.Element {
           />
           <span className="toolbar-toggle-label">Auto-save</span>
         </label>
-        <label className="toolbar-toggle" title="Lefty Flip: mirror highway for left-handed players">
+        <label
+          className="toolbar-toggle"
+          title="Lefty Flip: mirror highway for left-handed players"
+        >
           <input
             type="checkbox"
             checked={leftyFlip ?? false}
@@ -952,12 +1119,21 @@ export function Toolbar(): React.JSX.Element {
         <button
           className="toolbar-button toolbar-button-accent"
           disabled={!enableAutoChart}
-          title={enableAutoChart ? 'Generate a chart package from audio with STRUM' : 'Enable STRUM auto-charting in Settings'}
+          title={
+            enableAutoChart
+              ? 'Generate a chart package from audio with STRUM'
+              : 'Enable STRUM auto-charting in Settings'
+          }
           onClick={openAutoChartModal}
         >
           <span className="toolbar-icon">🤖</span>
           <span className="toolbar-label">Auto-Chart</span>
-          <span className="toolbar-experimental-tag" title="Auto-charting is experimental — results vary by song.">experimental</span>
+          <span
+            className="toolbar-experimental-tag"
+            title="Auto-charting is experimental — results vary by song."
+          >
+            experimental
+          </span>
         </button>
       </div>
 
@@ -965,77 +1141,185 @@ export function Toolbar(): React.JSX.Element {
 
       {/* Validate chart */}
       <div className="toolbar-group">
+        <style>{`
+          @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+          }
+        `}</style>
         <button
           className="toolbar-button"
-          disabled={!activeSongId}
+          disabled={!activeSongId || isValidating}
           title="Validate Chart"
           onClick={() => {
-            if (!activeSongId) return
-            const state = getSongStore(activeSongId).getState()
-            const issues = validateChart(state.song)
-            setValidationIssues(issues)
+            if (!activeSongId || isValidating) return
+            setIsValidating(true)
+            const startTime = Date.now()
+            setTimeout(async () => {
+              try {
+                const state = getSongStore(activeSongId).getState()
+                const settings = useSettingsStore.getState()
+                const issues = await validateChartAsync(state.song, settings)
+
+                const elapsed = Date.now() - startTime
+                const remaining = Math.max(0, 500 - elapsed)
+                if (remaining > 0) {
+                  await new Promise((resolve) => setTimeout(resolve, remaining))
+                }
+
+                setValidationIssues(issues)
+              } catch (err) {
+                console.error('[Validate Action Error]', err)
+              } finally {
+                setIsValidating(false)
+              }
+            }, 50)
           }}
         >
-          <span className="toolbar-icon">✓</span>
-          <span className="toolbar-label">Validate</span>
+          {isValidating ? (
+            <span
+              className="toolbar-icon"
+              style={{ display: 'inline-block', animation: 'spin 1s linear infinite' }}
+            >
+              ↻
+            </span>
+          ) : (
+            <span className="toolbar-icon">✓</span>
+          )}
+          <span className="toolbar-label">{isValidating ? 'Validating...' : 'Validate'}</span>
         </button>
       </div>
 
       {/* Validation results modal */}
-      {validationIssues !== null && (
+      {validationIssues !== null && songStore !== null && (
         <div
           style={{
-            position: 'fixed', inset: 0, zIndex: 9999,
-            backgroundColor: 'rgba(0,0,0,0.6)',
-            display: 'flex', alignItems: 'center', justifyContent: 'center'
+            position: 'fixed',
+            inset: 0,
+            zIndex: 9999,
+            backgroundColor: 'rgba(0,0,0,0.7)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
           }}
           onClick={() => setValidationIssues(null)}
         >
           <div
             style={{
-              backgroundColor: '#1e1e2e', border: '1px solid #444', borderRadius: 8,
-              padding: '20px 24px', minWidth: 400, maxWidth: 600, maxHeight: '70vh',
-              overflow: 'auto', boxShadow: '0 8px 32px rgba(0,0,0,0.5)'
+              backgroundColor: '#161622',
+              border: '1px solid #2d2d3d',
+              borderRadius: 8,
+              padding: '24px',
+              width: '1000px',
+              maxWidth: '95vw',
+              maxHeight: '80vh',
+              overflowY: 'auto',
+              boxShadow: '0 12px 40px rgba(0,0,0,0.6)',
+              display: 'flex',
+              flexDirection: 'column'
             }}
-            onClick={e => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
           >
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
-              <h3 style={{ margin: 0, color: '#fff', fontSize: 16 }}>Chart Validation</h3>
-              <button
-                style={{ background: 'none', border: 'none', color: '#aaa', cursor: 'pointer', fontSize: 18, lineHeight: 1 }}
-                onClick={() => setValidationIssues(null)}
-              >✕</button>
+            {(() => {
+              const hasOverlaps = validationIssues.some((issue) =>
+                issue.message.toLowerCase().includes('overlapping note')
+              )
+              return (
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    marginBottom: 16
+                  }}
+                >
+                  <h3 style={{ margin: 0, color: '#fff', fontSize: 18, fontWeight: 700 }}>
+                    Chart Validation
+                  </h3>
+                  {hasOverlaps && (
+                    <button
+                      onClick={cleanupAllDuplicates}
+                      style={{
+                        backgroundColor: '#ff4d4d',
+                        color: '#fff',
+                        border: 'none',
+                        borderRadius: '4px',
+                        padding: '6px 12px',
+                        fontSize: '12px',
+                        fontWeight: 600,
+                        cursor: 'pointer',
+                        marginLeft: '16px',
+                        marginRight: 'auto',
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: '6px',
+                        transition: 'background-color 0.2s',
+                        boxShadow: '0 2px 8px rgba(255, 77, 77, 0.3)'
+                      }}
+                      onMouseEnter={(e) => {
+                        e.currentTarget.style.backgroundColor = '#ff3333'
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.backgroundColor = '#ff4d4d'
+                      }}
+                    >
+                      ✨ Clean Up All Duplicates
+                    </button>
+                  )}
+                  <button
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      color: '#aaa',
+                      cursor: 'pointer',
+                      fontSize: 20,
+                      lineHeight: 1
+                    }}
+                    onClick={() => setValidationIssues(null)}
+                  >
+                    ✕
+                  </button>
+                </div>
+              )
+            })()}
+            <div style={{ flex: 1, overflowY: 'auto', paddingRight: '4px' }}>
+              {validationIssues.length === 0 ? (
+                <p style={{ color: '#2ecc71', margin: 0, fontWeight: 600, fontSize: 14 }}>
+                  ✓ No issues found!
+                </p>
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column' }}>
+                  {validationIssues.map((issue, i) => (
+                    <ValidationPreviewCard
+                      key={i}
+                      issue={issue}
+                      song={songStore.getState().song}
+                      activeSongId={activeSongId!}
+                    />
+                  ))}
+                </div>
+              )}
             </div>
-            {validationIssues.length === 0 ? (
-              <p style={{ color: '#9CF69A', margin: 0 }}>✓ No issues found!</p>
-            ) : (
-              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-                {validationIssues.map((issue, i) => (
-                  <li key={i} style={{
-                    padding: '6px 10px', marginBottom: 6, borderRadius: 4,
-                    backgroundColor: issue.severity === 'error' ? 'rgba(220,50,50,0.15)' : 'rgba(255,180,0,0.12)',
-                    borderLeft: `3px solid ${issue.severity === 'error' ? '#dc3232' : '#ffb400'}`,
-                    color: '#ddd', fontSize: 13
-                  }}>
-                    <span style={{ fontWeight: 600, color: issue.severity === 'error' ? '#f88' : '#ffcc44' }}>
-                      {issue.severity === 'error' ? '✖ Error' : '⚠ Warning'}
-                    </span>
-                    <span style={{ marginLeft: 8 }}>{issue.message}</span>
-                  </li>
-                ))}
-              </ul>
-            )}
           </div>
         </div>
       )}
 
       {isAutoChartModalOpen && (
-        <div className="settings-modal-overlay" onClick={() => !autoChartProgress.isRunning && setIsAutoChartModalOpen(false)}>
-          <div className="settings-modal auto-chart-modal" onClick={(event) => event.stopPropagation()}>
+        <div
+          className="settings-modal-overlay"
+          onClick={() => !autoChartProgress.isRunning && setIsAutoChartModalOpen(false)}
+        >
+          <div
+            className="settings-modal auto-chart-modal"
+            onClick={(event) => event.stopPropagation()}
+          >
             <div className="settings-modal-header">
               <div>
                 <h2 className="settings-modal-title">Auto-Chart from Audio</h2>
-                <p className="settings-modal-subtitle">Run STRUM on local audio files, folders, or URLs and load the generated chart package output.</p>
+                <p className="settings-modal-subtitle">
+                  Run STRUM on local audio files, folders, or URLs and load the generated chart
+                  package output.
+                </p>
               </div>
               <button
                 className="settings-modal-close"
@@ -1061,7 +1345,9 @@ export function Toolbar(): React.JSX.Element {
                       onClick={() => void handleSetupRuntime()}
                       disabled={isInstallingRuntime || runtimeStatus.installing}
                     >
-                      {isInstallingRuntime || runtimeStatus.installing ? 'Installing\u2026' : 'Set up Python runtime'}
+                      {isInstallingRuntime || runtimeStatus.installing
+                        ? 'Installing\u2026'
+                        : 'Set up Python runtime'}
                     </button>
                   </div>
                   {runtimeSetupError && (
@@ -1082,576 +1368,922 @@ export function Toolbar(): React.JSX.Element {
                 </div>
               )}
               {!autoChartProgress.isRunning && (
-              <>
-              <section className="settings-preferences-group">
-                <h3 className="settings-hotkey-group-title">Inputs</h3>
-                <fieldset
-                  disabled={autoChartProgress.isRunning}
-                  style={{ border: 'none', padding: 0, margin: 0, opacity: autoChartProgress.isRunning ? 0.55 : 1 }}
-                >
-                <div className="settings-preferences-body auto-chart-inputs">
-                  {/* Top-level: Full Mix vs Stems */}
-                  <div
-                    role="tablist"
-                    style={{
-                      display: 'flex',
-                      gap: 2,
-                      borderBottom: '1px solid #444',
-                      marginBottom: 12
-                    }}
-                  >
-                    {([
-                      { id: 'mix', label: 'Full Mix', count: autoChartFiles.length + autoChartFolders.length + autoChartUrls.filter((u) => u.trim()).length },
-                      { id: 'stems', label: 'Stems', count: autoChartStemSongs.filter((s) => Object.values(s.stems).some((v) => v.trim()) || s.extras.some((e) => e.trim())).length }
-                    ] as const).map((tab) => {
-                      const active = autoChartInputTab === tab.id
-                      return (
-                        <button
-                          key={tab.id}
-                          role="tab"
-                          aria-selected={active}
-                          onClick={() => setAutoChartInputTab(tab.id)}
+                <>
+                  <section className="settings-preferences-group">
+                    <h3 className="settings-hotkey-group-title">Inputs</h3>
+                    <fieldset
+                      disabled={autoChartProgress.isRunning}
+                      style={{
+                        border: 'none',
+                        padding: 0,
+                        margin: 0,
+                        opacity: autoChartProgress.isRunning ? 0.55 : 1
+                      }}
+                    >
+                      <div className="settings-preferences-body auto-chart-inputs">
+                        {/* Top-level: Full Mix vs Stems */}
+                        <div
+                          role="tablist"
                           style={{
-                            padding: '10px 18px',
-                            border: 'none',
-                            borderBottom: active ? '2px solid #4a9eff' : '2px solid transparent',
-                            background: active ? '#2a2a2a' : 'transparent',
-                            color: active ? '#fff' : '#bbb',
-                            cursor: 'pointer',
-                            fontWeight: active ? 600 : 500,
-                            fontSize: 14
+                            display: 'flex',
+                            gap: 2,
+                            borderBottom: '1px solid #444',
+                            marginBottom: 12
                           }}
                         >
-                          {tab.label}
-                          {tab.count > 0 && (
-                            <span
-                              style={{
-                                marginLeft: 8,
-                                padding: '1px 7px',
-                                background: '#4a9eff',
-                                color: '#fff',
-                                borderRadius: 10,
-                                fontSize: 11
-                              }}
-                            >
-                              {tab.count}
-                            </span>
-                          )}
-                        </button>
-                      )
-                    })}
-                  </div>
-
-                  {autoChartInputTab === 'mix' && (
-                    <div>
-                      {/* Sub-tabs: Audio Files / Audio Folders / URLs */}
-                      <div
-                        role="tablist"
-                        style={{
-                          display: 'flex',
-                          gap: 2,
-                          borderBottom: '1px solid #2f2f2f',
-                          marginBottom: 12
-                        }}
-                      >
-                        {([
-                          { id: 'files', label: 'Audio Files', count: autoChartFiles.length },
-                          { id: 'folders', label: 'Audio Folders', count: autoChartFolders.length },
-                          { id: 'urls', label: 'URLs', count: autoChartUrls.filter((u) => u.trim()).length }
-                        ] as const).map((tab) => {
-                          const active = autoChartFullMixSubTab === tab.id
-                          return (
-                            <button
-                              key={tab.id}
-                              role="tab"
-                              aria-selected={active}
-                              onClick={() => setAutoChartFullMixSubTab(tab.id)}
-                              style={{
-                                padding: '6px 12px',
-                                border: 'none',
-                                borderBottom: active ? '2px solid #4a9eff' : '2px solid transparent',
-                                background: 'transparent',
-                                color: active ? '#fff' : '#999',
-                                cursor: 'pointer',
-                                fontWeight: active ? 600 : 400,
-                                fontSize: 12
-                              }}
-                            >
-                              {tab.label}
-                              {tab.count > 0 && (
-                                <span style={{ marginLeft: 6, padding: '1px 6px', background: '#4a9eff', color: '#fff', borderRadius: 10, fontSize: 10 }}>{tab.count}</span>
-                              )}
-                            </button>
-                          )
-                        })}
-                      </div>
-
-                      {autoChartFullMixSubTab === 'files' && (
-                        <>
-                          <div className="auto-chart-actions-row">
-                            <button className="settings-modal-secondary" onClick={async () => {
-                              const files = await window.api.openAudioFilesDialog()
-                              if (files.length > 0) {
-                                setAutoChartFiles((prev) => Array.from(new Set([...prev, ...files])))
+                          {(
+                            [
+                              {
+                                id: 'mix',
+                                label: 'Full Mix',
+                                count:
+                                  autoChartFiles.length +
+                                  autoChartFolders.length +
+                                  autoChartUrls.filter((u) => u.trim()).length
+                              },
+                              {
+                                id: 'stems',
+                                label: 'Stems',
+                                count: autoChartStemSongs.filter(
+                                  (s) =>
+                                    Object.values(s.stems).some((v) => v.trim()) ||
+                                    s.extras.some((e) => e.trim())
+                                ).length
                               }
-                            }}>Add Files</button>
-                          </div>
-                          <p style={{ fontSize: 12, opacity: 0.7, margin: '6px 0 4px' }}>
-                            Pick one or more individual audio files (.wav/.ogg/.opus/.mp3/.flac).
-                          </p>
-                          <div className="auto-chart-chip-list">
-                            {autoChartFiles.map((file) => (
-                              <button key={file} className="auto-chart-chip" onClick={() => setAutoChartFiles((prev) => prev.filter((entry) => entry !== file))}>
-                                {file.split(/[\\/]/).pop()} ×
-                              </button>
-                            ))}
-                          </div>
-                        </>
-                      )}
-
-                      {autoChartFullMixSubTab === 'folders' && (
-                        <>
-                          <div className="auto-chart-actions-row">
-                            <button className="settings-modal-secondary" onClick={async () => {
-                              const folder = await window.api.openAudioFolderDialog()
-                              if (folder) {
-                                setAutoChartFolders((prev) => Array.from(new Set([...prev, folder])))
-                              }
-                            }}>Add Folder</button>
-                          </div>
-                          <p style={{ fontSize: 12, opacity: 0.7, margin: '6px 0 4px' }}>
-                            Each folder is scanned for supported audio files; every file is processed as its own song.
-                          </p>
-                          <div className="auto-chart-chip-list">
-                            {autoChartFolders.map((folder) => (
-                              <button key={folder} className="auto-chart-chip" onClick={() => setAutoChartFolders((prev) => prev.filter((entry) => entry !== folder))}>
-                                {folder.split(/[\\/]/).pop()} ×
-                              </button>
-                            ))}
-                          </div>
-                        </>
-                      )}
-
-                      {autoChartFullMixSubTab === 'urls' && (
-                        <div className="settings-field-stack">
-                          <div className="auto-chart-url-header">
-                            <label className="settings-field-label" htmlFor="auto-chart-url-0">Audio / YouTube URLs</label>
-                            <button className="auto-chart-icon-button" onClick={handleAddAutoChartUrl} title="Add URL row" aria-label="Add URL row">+</button>
-                          </div>
-                          <div className="auto-chart-url-list">
-                            {autoChartUrls.map((url, index) => (
-                              <div key={`auto-chart-url-${index}`} className="auto-chart-url-row">
-                                <input
-                                  id={`auto-chart-url-${index}`}
-                                  className="settings-folder-input auto-chart-url-input"
-                                  type="text"
-                                  value={url}
-                                  onChange={(event) => handleUpdateAutoChartUrl(index, event.target.value)}
-                                  placeholder="Paste an audio or YouTube URL"
-                                />
-                                <button
-                                  className="auto-chart-icon-button auto-chart-delete-button"
-                                  onClick={() => handleRemoveAutoChartUrl(index)}
-                                  title="Remove URL row"
-                                  aria-label="Remove URL row"
-                                >
-                                  🗑
-                                </button>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  )}
-
-                  {autoChartInputTab === 'stems' && (
-                    <div>
-                      <p style={{ fontSize: 12, opacity: 0.75, margin: '0 0 10px' }}>
-                        Provide one file or URL per instrument. Empty slots are skipped — that instrument will not be charted, and the Demucs separation phase is skipped entirely (your stems are used as-is). The full mix is always auto-generated by summing your stems and any extra audio. Lead vocals are charted strictly as PART VOCALS; backing vocals 1/2 drive HARM2/HARM3 and play back as vocals_1.ogg/vocals_2.ogg. Anything you add as “Extra audio” is combined into other.ogg (the catch-all uncharted track); the optional Crowd slot is exported directly as crowd.ogg.
-                      </p>
-                      {autoChartStemSongs.map((song, songIdx) => (
-                        <div key={song.id} style={{ border: '1px solid #333', borderRadius: 6, padding: 12, marginBottom: 10, background: '#1c1c1c' }}>
-                          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
-                            <input
-                              type="text"
-                              className="settings-folder-input"
-                              value={song.name}
-                              onChange={(event) => {
-                                const v = event.target.value
-                                setAutoChartStemSongs((prev) => prev.map((s, i) => i === songIdx ? { ...s, name: v } : s))
-                              }}
-                              placeholder="Song name (used for output folder)"
-                              style={{ flex: 1 }}
-                            />
-                            {autoChartStemSongs.length > 1 && (
+                            ] as const
+                          ).map((tab) => {
+                            const active = autoChartInputTab === tab.id
+                            return (
                               <button
-                                type="button"
-                                className="auto-chart-icon-button auto-chart-delete-button"
-                                onClick={() => setAutoChartStemSongs((prev) => prev.filter((_, i) => i !== songIdx))}
-                                title="Remove this stem song"
-                                aria-label="Remove stem song"
-                              >🗑</button>
+                                key={tab.id}
+                                role="tab"
+                                aria-selected={active}
+                                onClick={() => setAutoChartInputTab(tab.id)}
+                                style={{
+                                  padding: '10px 18px',
+                                  border: 'none',
+                                  borderBottom: active
+                                    ? '2px solid #4a9eff'
+                                    : '2px solid transparent',
+                                  background: active ? '#2a2a2a' : 'transparent',
+                                  color: active ? '#fff' : '#bbb',
+                                  cursor: 'pointer',
+                                  fontWeight: active ? 600 : 500,
+                                  fontSize: 14
+                                }}
+                              >
+                                {tab.label}
+                                {tab.count > 0 && (
+                                  <span
+                                    style={{
+                                      marginLeft: 8,
+                                      padding: '1px 7px',
+                                      background: '#4a9eff',
+                                      color: '#fff',
+                                      borderRadius: 10,
+                                      fontSize: 11
+                                    }}
+                                  >
+                                    {tab.count}
+                                  </span>
+                                )}
+                              </button>
+                            )
+                          })}
+                        </div>
+
+                        {autoChartInputTab === 'mix' && (
+                          <div>
+                            {/* Sub-tabs: Audio Files / Audio Folders / URLs */}
+                            <div
+                              role="tablist"
+                              style={{
+                                display: 'flex',
+                                gap: 2,
+                                borderBottom: '1px solid #2f2f2f',
+                                marginBottom: 12
+                              }}
+                            >
+                              {(
+                                [
+                                  {
+                                    id: 'files',
+                                    label: 'Audio Files',
+                                    count: autoChartFiles.length
+                                  },
+                                  {
+                                    id: 'folders',
+                                    label: 'Audio Folders',
+                                    count: autoChartFolders.length
+                                  },
+                                  {
+                                    id: 'urls',
+                                    label: 'URLs',
+                                    count: autoChartUrls.filter((u) => u.trim()).length
+                                  }
+                                ] as const
+                              ).map((tab) => {
+                                const active = autoChartFullMixSubTab === tab.id
+                                return (
+                                  <button
+                                    key={tab.id}
+                                    role="tab"
+                                    aria-selected={active}
+                                    onClick={() => setAutoChartFullMixSubTab(tab.id)}
+                                    style={{
+                                      padding: '6px 12px',
+                                      border: 'none',
+                                      borderBottom: active
+                                        ? '2px solid #4a9eff'
+                                        : '2px solid transparent',
+                                      background: 'transparent',
+                                      color: active ? '#fff' : '#999',
+                                      cursor: 'pointer',
+                                      fontWeight: active ? 600 : 400,
+                                      fontSize: 12
+                                    }}
+                                  >
+                                    {tab.label}
+                                    {tab.count > 0 && (
+                                      <span
+                                        style={{
+                                          marginLeft: 6,
+                                          padding: '1px 6px',
+                                          background: '#4a9eff',
+                                          color: '#fff',
+                                          borderRadius: 10,
+                                          fontSize: 10
+                                        }}
+                                      >
+                                        {tab.count}
+                                      </span>
+                                    )}
+                                  </button>
+                                )
+                              })}
+                            </div>
+
+                            {autoChartFullMixSubTab === 'files' && (
+                              <>
+                                <div className="auto-chart-actions-row">
+                                  <button
+                                    className="settings-modal-secondary"
+                                    onClick={async () => {
+                                      const files = await window.api.openAudioFilesDialog()
+                                      if (files.length > 0) {
+                                        setAutoChartFiles((prev) =>
+                                          Array.from(new Set([...prev, ...files]))
+                                        )
+                                      }
+                                    }}
+                                  >
+                                    Add Files
+                                  </button>
+                                </div>
+                                <p style={{ fontSize: 12, opacity: 0.7, margin: '6px 0 4px' }}>
+                                  Pick one or more individual audio files
+                                  (.wav/.ogg/.opus/.mp3/.flac).
+                                </p>
+                                <div className="auto-chart-chip-list">
+                                  {autoChartFiles.map((file) => (
+                                    <button
+                                      key={file}
+                                      className="auto-chart-chip"
+                                      onClick={() =>
+                                        setAutoChartFiles((prev) =>
+                                          prev.filter((entry) => entry !== file)
+                                        )
+                                      }
+                                    >
+                                      {file.split(/[\\/]/).pop()} ×
+                                    </button>
+                                  ))}
+                                </div>
+                              </>
+                            )}
+
+                            {autoChartFullMixSubTab === 'folders' && (
+                              <>
+                                <div className="auto-chart-actions-row">
+                                  <button
+                                    className="settings-modal-secondary"
+                                    onClick={async () => {
+                                      const folder = await window.api.openAudioFolderDialog()
+                                      if (folder) {
+                                        setAutoChartFolders((prev) =>
+                                          Array.from(new Set([...prev, folder]))
+                                        )
+                                      }
+                                    }}
+                                  >
+                                    Add Folder
+                                  </button>
+                                </div>
+                                <p style={{ fontSize: 12, opacity: 0.7, margin: '6px 0 4px' }}>
+                                  Each folder is scanned for supported audio files; every file is
+                                  processed as its own song.
+                                </p>
+                                <div className="auto-chart-chip-list">
+                                  {autoChartFolders.map((folder) => (
+                                    <button
+                                      key={folder}
+                                      className="auto-chart-chip"
+                                      onClick={() =>
+                                        setAutoChartFolders((prev) =>
+                                          prev.filter((entry) => entry !== folder)
+                                        )
+                                      }
+                                    >
+                                      {folder.split(/[\\/]/).pop()} ×
+                                    </button>
+                                  ))}
+                                </div>
+                              </>
+                            )}
+
+                            {autoChartFullMixSubTab === 'urls' && (
+                              <div className="settings-field-stack">
+                                <div className="auto-chart-url-header">
+                                  <label
+                                    className="settings-field-label"
+                                    htmlFor="auto-chart-url-0"
+                                  >
+                                    Audio / YouTube URLs
+                                  </label>
+                                  <button
+                                    className="auto-chart-icon-button"
+                                    onClick={handleAddAutoChartUrl}
+                                    title="Add URL row"
+                                    aria-label="Add URL row"
+                                  >
+                                    +
+                                  </button>
+                                </div>
+                                <div className="auto-chart-url-list">
+                                  {autoChartUrls.map((url, index) => (
+                                    <div
+                                      key={`auto-chart-url-${index}`}
+                                      className="auto-chart-url-row"
+                                    >
+                                      <input
+                                        id={`auto-chart-url-${index}`}
+                                        className="settings-folder-input auto-chart-url-input"
+                                        type="text"
+                                        value={url}
+                                        onChange={(event) =>
+                                          handleUpdateAutoChartUrl(index, event.target.value)
+                                        }
+                                        placeholder="Paste an audio or YouTube URL"
+                                      />
+                                      <button
+                                        className="auto-chart-icon-button auto-chart-delete-button"
+                                        onClick={() => handleRemoveAutoChartUrl(index)}
+                                        title="Remove URL row"
+                                        aria-label="Remove URL row"
+                                      >
+                                        🗑
+                                      </button>
+                                    </div>
+                                  ))}
+                                </div>
+                              </div>
                             )}
                           </div>
-                          <div style={{ display: 'grid', gap: 6 }}>
-                            {([
-                              { key: 'drums', label: 'Drums' },
-                              { key: 'bass', label: 'Bass' },
-                              { key: 'vocals', label: 'Vocals (lead)' },
-                              { key: 'vocalsHarm2', label: 'Backing Vocals 1' },
-                              { key: 'vocalsHarm3', label: 'Backing Vocals 2' },
-                              { key: 'guitar', label: 'Guitar' },
-                              { key: 'piano', label: 'Piano / Keys' },
-                              { key: 'crowd', label: 'Crowd (optional)' }
-                            ] as const).map((row) => (
-                              <div key={row.key} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                                <label style={{ width: 140, fontSize: 12, opacity: 0.85 }}>{row.label}</label>
-                                <input
-                                  type="text"
-                                  className="settings-folder-input"
-                                  value={song.stems[row.key]}
-                                  onChange={(event) => {
-                                    const v = event.target.value
-                                    setAutoChartStemSongs((prev) => prev.map((s, i) => i === songIdx ? { ...s, stems: { ...s.stems, [row.key]: v } } : s))
+                        )}
+
+                        {autoChartInputTab === 'stems' && (
+                          <div>
+                            <p style={{ fontSize: 12, opacity: 0.75, margin: '0 0 10px' }}>
+                              Provide one file or URL per instrument. Empty slots are skipped — that
+                              instrument will not be charted, and the Demucs separation phase is
+                              skipped entirely (your stems are used as-is). The full mix is always
+                              auto-generated by summing your stems and any extra audio. Lead vocals
+                              are charted strictly as PART VOCALS; backing vocals 1/2 drive
+                              HARM2/HARM3 and play back as vocals_1.ogg/vocals_2.ogg. Anything you
+                              add as “Extra audio” is combined into other.ogg (the catch-all
+                              uncharted track); the optional Crowd slot is exported directly as
+                              crowd.ogg.
+                            </p>
+                            {autoChartStemSongs.map((song, songIdx) => (
+                              <div
+                                key={song.id}
+                                style={{
+                                  border: '1px solid #333',
+                                  borderRadius: 6,
+                                  padding: 12,
+                                  marginBottom: 10,
+                                  background: '#1c1c1c'
+                                }}
+                              >
+                                <div
+                                  style={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 8,
+                                    marginBottom: 10
                                   }}
-                                  placeholder="File path or URL — leave blank to skip"
-                                  style={{ flex: 1 }}
-                                />
-                                <button
-                                  type="button"
-                                  className="settings-modal-secondary"
-                                  style={{ padding: '4px 10px', fontSize: 12 }}
-                                  onClick={async () => {
-                                    const files = await window.api.openAudioFilesDialog()
-                                    const picked = files[0]
-                                    if (picked) {
-                                      setAutoChartStemSongs((prev) => prev.map((s, i) => i === songIdx ? { ...s, stems: { ...s.stems, [row.key]: picked } } : s))
-                                    }
-                                  }}
-                                >Browse…</button>
-                              </div>
-                            ))}
-                          </div>
-                          <div style={{ marginTop: 10, paddingTop: 10, borderTop: '1px dashed #333' }}>
-                            <div style={{ fontSize: 12, opacity: 0.75, marginBottom: 6 }}>
-                              Extra audio (uncharted) — anything you add here is summed together and exported as <code style={{ fontSize: 11 }}>other.ogg</code> (the catch-all uncharted bucket).
-                            </div>
-                            <div style={{ display: 'grid', gap: 6 }}>
-                              {song.extras.map((extra, extraIdx) => (
-                                <div key={extraIdx} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                                  <label style={{ width: 140, fontSize: 12, opacity: 0.85 }}>Extra {extraIdx + 1}</label>
+                                >
                                   <input
                                     type="text"
                                     className="settings-folder-input"
-                                    value={extra}
+                                    value={song.name}
                                     onChange={(event) => {
                                       const v = event.target.value
-                                      setAutoChartStemSongs((prev) => prev.map((s, i) => i === songIdx ? { ...s, extras: s.extras.map((e, j) => j === extraIdx ? v : e) } : s))
+                                      setAutoChartStemSongs((prev) =>
+                                        prev.map((s, i) => (i === songIdx ? { ...s, name: v } : s))
+                                      )
                                     }}
-                                    placeholder="File path or URL"
+                                    placeholder="Song name (used for output folder)"
                                     style={{ flex: 1 }}
                                   />
-                                  <button
-                                    type="button"
-                                    className="settings-modal-secondary"
-                                    style={{ padding: '4px 10px', fontSize: 12 }}
-                                    onClick={async () => {
-                                      const files = await window.api.openAudioFilesDialog()
-                                      const picked = files[0]
-                                      if (picked) {
-                                        setAutoChartStemSongs((prev) => prev.map((s, i) => i === songIdx ? { ...s, extras: s.extras.map((e, j) => j === extraIdx ? picked : e) } : s))
+                                  {autoChartStemSongs.length > 1 && (
+                                    <button
+                                      type="button"
+                                      className="auto-chart-icon-button auto-chart-delete-button"
+                                      onClick={() =>
+                                        setAutoChartStemSongs((prev) =>
+                                          prev.filter((_, i) => i !== songIdx)
+                                        )
                                       }
-                                    }}
-                                  >Browse…</button>
-                                  <button
-                                    type="button"
-                                    className="auto-chart-icon-button auto-chart-delete-button"
-                                    onClick={() => setAutoChartStemSongs((prev) => prev.map((s, i) => i === songIdx ? { ...s, extras: s.extras.filter((_, j) => j !== extraIdx) } : s))}
-                                    title="Remove this extra"
-                                    aria-label="Remove extra"
-                                  >🗑</button>
+                                      title="Remove this stem song"
+                                      aria-label="Remove stem song"
+                                    >
+                                      🗑
+                                    </button>
+                                  )}
                                 </div>
-                              ))}
-                              <button
-                                type="button"
-                                className="settings-modal-secondary"
-                                style={{ alignSelf: 'flex-start', padding: '4px 10px', fontSize: 12 }}
-                                onClick={() => setAutoChartStemSongs((prev) => prev.map((s, i) => i === songIdx ? { ...s, extras: [...s.extras, ''] } : s))}
-                              >+ Add extra audio</button>
-                            </div>
+                                <div style={{ display: 'grid', gap: 6 }}>
+                                  {(
+                                    [
+                                      { key: 'drums', label: 'Drums' },
+                                      { key: 'bass', label: 'Bass' },
+                                      { key: 'vocals', label: 'Vocals (lead)' },
+                                      { key: 'vocalsHarm2', label: 'Backing Vocals 1' },
+                                      { key: 'vocalsHarm3', label: 'Backing Vocals 2' },
+                                      { key: 'guitar', label: 'Guitar' },
+                                      { key: 'piano', label: 'Piano / Keys' },
+                                      { key: 'crowd', label: 'Crowd (optional)' }
+                                    ] as const
+                                  ).map((row) => (
+                                    <div
+                                      key={row.key}
+                                      style={{ display: 'flex', alignItems: 'center', gap: 6 }}
+                                    >
+                                      <label style={{ width: 140, fontSize: 12, opacity: 0.85 }}>
+                                        {row.label}
+                                      </label>
+                                      <input
+                                        type="text"
+                                        className="settings-folder-input"
+                                        value={song.stems[row.key]}
+                                        onChange={(event) => {
+                                          const v = event.target.value
+                                          setAutoChartStemSongs((prev) =>
+                                            prev.map((s, i) =>
+                                              i === songIdx
+                                                ? { ...s, stems: { ...s.stems, [row.key]: v } }
+                                                : s
+                                            )
+                                          )
+                                        }}
+                                        placeholder="File path or URL — leave blank to skip"
+                                        style={{ flex: 1 }}
+                                      />
+                                      <button
+                                        type="button"
+                                        className="settings-modal-secondary"
+                                        style={{ padding: '4px 10px', fontSize: 12 }}
+                                        onClick={async () => {
+                                          const files = await window.api.openAudioFilesDialog()
+                                          const picked = files[0]
+                                          if (picked) {
+                                            setAutoChartStemSongs((prev) =>
+                                              prev.map((s, i) =>
+                                                i === songIdx
+                                                  ? {
+                                                      ...s,
+                                                      stems: { ...s.stems, [row.key]: picked }
+                                                    }
+                                                  : s
+                                              )
+                                            )
+                                          }
+                                        }}
+                                      >
+                                        Browse…
+                                      </button>
+                                    </div>
+                                  ))}
+                                </div>
+                                <div
+                                  style={{
+                                    marginTop: 10,
+                                    paddingTop: 10,
+                                    borderTop: '1px dashed #333'
+                                  }}
+                                >
+                                  <div style={{ fontSize: 12, opacity: 0.75, marginBottom: 6 }}>
+                                    Extra audio (uncharted) — anything you add here is summed
+                                    together and exported as{' '}
+                                    <code style={{ fontSize: 11 }}>other.ogg</code> (the catch-all
+                                    uncharted bucket).
+                                  </div>
+                                  <div style={{ display: 'grid', gap: 6 }}>
+                                    {song.extras.map((extra, extraIdx) => (
+                                      <div
+                                        key={extraIdx}
+                                        style={{ display: 'flex', alignItems: 'center', gap: 6 }}
+                                      >
+                                        <label style={{ width: 140, fontSize: 12, opacity: 0.85 }}>
+                                          Extra {extraIdx + 1}
+                                        </label>
+                                        <input
+                                          type="text"
+                                          className="settings-folder-input"
+                                          value={extra}
+                                          onChange={(event) => {
+                                            const v = event.target.value
+                                            setAutoChartStemSongs((prev) =>
+                                              prev.map((s, i) =>
+                                                i === songIdx
+                                                  ? {
+                                                      ...s,
+                                                      extras: s.extras.map((e, j) =>
+                                                        j === extraIdx ? v : e
+                                                      )
+                                                    }
+                                                  : s
+                                              )
+                                            )
+                                          }}
+                                          placeholder="File path or URL"
+                                          style={{ flex: 1 }}
+                                        />
+                                        <button
+                                          type="button"
+                                          className="settings-modal-secondary"
+                                          style={{ padding: '4px 10px', fontSize: 12 }}
+                                          onClick={async () => {
+                                            const files = await window.api.openAudioFilesDialog()
+                                            const picked = files[0]
+                                            if (picked) {
+                                              setAutoChartStemSongs((prev) =>
+                                                prev.map((s, i) =>
+                                                  i === songIdx
+                                                    ? {
+                                                        ...s,
+                                                        extras: s.extras.map((e, j) =>
+                                                          j === extraIdx ? picked : e
+                                                        )
+                                                      }
+                                                    : s
+                                                )
+                                              )
+                                            }
+                                          }}
+                                        >
+                                          Browse…
+                                        </button>
+                                        <button
+                                          type="button"
+                                          className="auto-chart-icon-button auto-chart-delete-button"
+                                          onClick={() =>
+                                            setAutoChartStemSongs((prev) =>
+                                              prev.map((s, i) =>
+                                                i === songIdx
+                                                  ? {
+                                                      ...s,
+                                                      extras: s.extras.filter(
+                                                        (_, j) => j !== extraIdx
+                                                      )
+                                                    }
+                                                  : s
+                                              )
+                                            )
+                                          }
+                                          title="Remove this extra"
+                                          aria-label="Remove extra"
+                                        >
+                                          🗑
+                                        </button>
+                                      </div>
+                                    ))}
+                                    <button
+                                      type="button"
+                                      className="settings-modal-secondary"
+                                      style={{
+                                        alignSelf: 'flex-start',
+                                        padding: '4px 10px',
+                                        fontSize: 12
+                                      }}
+                                      onClick={() =>
+                                        setAutoChartStemSongs((prev) =>
+                                          prev.map((s, i) =>
+                                            i === songIdx ? { ...s, extras: [...s.extras, ''] } : s
+                                          )
+                                        )
+                                      }
+                                    >
+                                      + Add extra audio
+                                    </button>
+                                  </div>
+                                </div>
+                              </div>
+                            ))}
+                            <button
+                              type="button"
+                              className="settings-modal-secondary"
+                              onClick={() =>
+                                setAutoChartStemSongs((prev) => [...prev, makeEmptyStemSong()])
+                              }
+                            >
+                              + Add another stem song
+                            </button>
                           </div>
-                        </div>
-                      ))}
-                      <button
-                        type="button"
-                        className="settings-modal-secondary"
-                        onClick={() => setAutoChartStemSongs((prev) => [...prev, makeEmptyStemSong()])}
-                      >+ Add another stem song</button>
-                    </div>
-                  )}
+                        )}
 
-                  <div className="settings-field-stack" style={{ marginTop: 16, paddingTop: 12, borderTop: '1px solid #333' }}>
-                    <label className="settings-field-label" htmlFor="auto-chart-output">Output folder</label>
-                    <div style={{ display: 'flex', gap: 6 }}>
-                      <input
-                        id="auto-chart-output"
-                        className="settings-folder-input"
-                        type="text"
-                        value={autoChartProgress.outputDir}
-                        onChange={(event) => setAutoChartProgress((prev) => ({ ...prev, outputDir: event.target.value }))}
-                        placeholder="Generated song folders will be written here"
-                        style={{ flex: 1 }}
-                      />
-                      <button className="settings-modal-secondary" onClick={async () => {
-                        const folder = await window.api.openOutputFolderDialog()
-                        if (folder) {
-                          setAutoChartProgress((prev) => ({ ...prev, outputDir: folder, error: null }))
-                        }
-                      }}>Browse…</button>
-                    </div>
-                  </div>
-                </div>
-                </fieldset>
-              </section>
-
-              <section className="settings-preferences-group">
-                <button
-                  type="button"
-                  className="auto-chart-collapse-toggle"
-                  onClick={() => setAutoChartAdvancedOpen((v) => !v)}
-                  aria-expanded={autoChartAdvancedOpen}
-                >
-                  <span className="auto-chart-collapse-chevron" aria-hidden="true">
-                    <svg viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-                      <path d="M4 2.5L8 6L4 9.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                    </svg>
-                  </span>
-                  <span>Advanced</span>
-                </button>
-                {autoChartAdvancedOpen && (
-                <div className="settings-preferences-body">
-                  <label className="settings-checkbox-row">
-                    <input
-                      type="checkbox"
-                      checked={autoChartDisableOnlineLookup}
-                      onChange={(event) => setAutoChartDisableOnlineLookup(event.target.checked)}
-                      disabled={autoChartProgress.isRunning}
-                    />
-                    <span>
-                      Offline mode (disable online lookups)
-                      <small style={{ display: 'block', opacity: 0.7 }}>
-                        Skips MusicBrainz, album art, and lyric searches. Use this for custom uploads to avoid them being misidentified as other songs.
-                      </small>
-                    </span>
-                  </label>
-
-                  <label className="settings-checkbox-row">
-                    <input
-                      type="checkbox"
-                      checked={autoChartDownloadVideo}
-                      onChange={(event) => setAutoChartDownloadVideo(event.target.checked)}
-                      disabled={autoChartProgress.isRunning}
-                    />
-                    <span>
-                      Download video for URL inputs
-                      <small style={{ display: 'block', opacity: 0.7 }}>
-                        After charting finishes, pull the source video (e.g. YouTube) into each song folder so it plays in the timeline and in-game.
-                      </small>
-                    </span>
-                  </label>
-
-                  <label className="settings-checkbox-row">
-                    <input
-                      type="checkbox"
-                      checked={autoChartKeepStems}
-                      onChange={(event) => setAutoChartKeepStems(event.target.checked)}
-                      disabled={autoChartProgress.isRunning}
-                    />
-                    <span>
-                      Keep separated stems
-                      <small style={{ display: 'block', opacity: 0.7 }}>
-                        Export the separated stems (drums, bass, vocals, etc.) as per-instrument oggs in each song folder instead of discarding them. Lets you remix or mute instruments in-game.
-                      </small>
-                    </span>
-                  </label>
-
-                  <label className="settings-checkbox-row">
-                    <input
-                      type="checkbox"
-                      checked={autoChartImproveTempo}
-                      onChange={(event) => setAutoChartImproveTempo(event.target.checked)}
-                      disabled={autoChartProgress.isRunning}
-                    />
-                    <span>
-                      Improve tempo accuracy (recommended)
-                      <small style={{ display: 'block', opacity: 0.7 }}>
-                        Beat-tracks the audio to align the chart&rsquo;s beat and measure lines to the real performance, so notes stop drifting off the grid. Follows tempo changes in live recordings while keeping notes in sync with the audio. Disabled automatically when you set a manual tempo map below.
-                      </small>
-                    </span>
-                  </label>
-
-                  <div className="auto-chart-bpm-source" style={{ margin: '4px 0 2px' }}>
-                    <label className="settings-checkbox-row" style={{ alignItems: 'flex-start' }}>
-                      <span style={{ flex: 1 }}>
-                        Manual BPM
-                        <small style={{ display: 'block', opacity: 0.7 }}>
-                          Know the song&rsquo;s tempo? Enter it and it&rsquo;s treated as the truth: the beat grid is locked to this BPM (fixing any wrong-tempo or octave detection). With &ldquo;Improve tempo accuracy&rdquo; on, the audio is still beat-tracked to follow drift around this value; with it off, this exact BPM is applied. Leave blank to detect automatically.
-                        </small>
-                      </span>
-                      <input
-                        type="number"
-                        min={1}
-                        step={0.001}
-                        value={autoChartManualBpm}
-                        placeholder="auto"
-                        disabled={autoChartProgress.isRunning}
-                        style={{ width: 84, marginLeft: 12 }}
-                        onChange={(event) => setAutoChartManualBpm(event.target.value)}
-                      />
-                    </label>
-                  </div>
-
-                  <label className="settings-checkbox-row">
-                    <input
-                      type="checkbox"
-                      checked={autoChartSnapDrums}
-                      onChange={(event) => setAutoChartSnapDrums(event.target.checked)}
-                      disabled={autoChartProgress.isRunning}
-                    />
-                    <span>
-                      Snap drums to grid
-                      <small style={{ display: 'block', opacity: 0.7 }}>
-                        Nudge drum notes that land just off the beat onto the nearest 1/32 grid line, removing the slight timing jitter from onset detection. Genuinely off-grid hits (fills, syncopation) are left untouched.
-                      </small>
-                    </span>
-                  </label>
-
-                  <div style={{ marginTop: 12 }}>
-                    {autoChartInputTab === 'stems' ? (
-                      <p style={{ fontSize: 12, opacity: 0.7, margin: 0 }}>
-                        Tracks to chart are determined automatically from the stems you provide on the Stems tab — only instruments with a stem will be charted.
-                      </p>
-                    ) : (
-                      <>
-                        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
-                          <strong style={{ fontSize: 13 }}>Tracks to chart</strong>
+                        <div
+                          className="settings-field-stack"
+                          style={{ marginTop: 16, paddingTop: 12, borderTop: '1px solid #333' }}
+                        >
+                          <label className="settings-field-label" htmlFor="auto-chart-output">
+                            Output folder
+                          </label>
                           <div style={{ display: 'flex', gap: 6 }}>
+                            <input
+                              id="auto-chart-output"
+                              className="settings-folder-input"
+                              type="text"
+                              value={autoChartProgress.outputDir}
+                              onChange={(event) =>
+                                setAutoChartProgress((prev) => ({
+                                  ...prev,
+                                  outputDir: event.target.value
+                                }))
+                              }
+                              placeholder="Generated song folders will be written here"
+                              style={{ flex: 1 }}
+                            />
                             <button
-                              type="button"
                               className="settings-modal-secondary"
-                              style={{ fontSize: 11, padding: '2px 8px' }}
-                              disabled={autoChartProgress.isRunning}
-                              onClick={() => setAutoChartEnabledTracks({ drums: true, guitar: true, bass: true, vocals: true, harmonies: true, keys: true, proKeys: true })}
-                            >All</button>
-                            <button
-                              type="button"
-                              className="settings-modal-secondary"
-                              style={{ fontSize: 11, padding: '2px 8px' }}
-                              disabled={autoChartProgress.isRunning}
-                              onClick={() => setAutoChartEnabledTracks({ drums: false, guitar: false, bass: false, vocals: false, harmonies: false, keys: false, proKeys: false })}
-                            >None</button>
+                              onClick={async () => {
+                                const folder = await window.api.openOutputFolderDialog()
+                                if (folder) {
+                                  setAutoChartProgress((prev) => ({
+                                    ...prev,
+                                    outputDir: folder,
+                                    error: null
+                                  }))
+                                }
+                              }}
+                            >
+                              Browse…
+                            </button>
                           </div>
                         </div>
-                        <p style={{ fontSize: 12, opacity: 0.7, margin: '0 0 8px' }}>
-                          Uncheck any track you do not want STRUM to generate. All are charted by default.
-                        </p>
-                        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: '6px 16px' }}>
-                          {([
-                            { key: 'drums', label: 'Drums' },
-                            { key: 'guitar', label: 'Guitar' },
-                            { key: 'bass', label: 'Bass' },
-                            { key: 'keys', label: 'Keys' },
-                            { key: 'proKeys', label: 'Pro Keys' },
-                            { key: 'vocals', label: 'Vocals' },
-                            { key: 'harmonies', label: 'Vocal Harmonies (HARM2/3)' }
-                          ] as const).map((track) => (
-                            <label key={track.key} className="settings-checkbox-row" style={{ margin: 0 }}>
-                              <input
-                                type="checkbox"
-                                checked={autoChartEnabledTracks[track.key]}
-                                disabled={autoChartProgress.isRunning || (track.key === 'harmonies' && !autoChartEnabledTracks.vocals)}
-                                onChange={(event) => setAutoChartEnabledTracks((prev) => {
-                                  const next = { ...prev, [track.key]: event.target.checked }
-                                  // Disabling vocals also disables harmonies.
-                                  if (track.key === 'vocals' && !event.target.checked) next.harmonies = false
-                                  return next
-                                })}
-                              />
-                              <span>{track.label}</span>
-                            </label>
-                          ))}
-                        </div>
-                      </>
-                    )}
-                  </div>
+                      </div>
+                    </fieldset>
+                  </section>
 
-                  <div className="auto-chart-tempo-override">
-                    <div className="auto-chart-tempo-header">
-                      <strong>Tempo override</strong>
-                      <button
-                        type="button"
-                        className="settings-modal-secondary"
-                        style={{ fontSize: 11, padding: '2px 8px' }}
-                        disabled={autoChartProgress.isRunning}
-                        onClick={() => setAutoChartTempoEvents((prev) => [
-                          ...prev,
-                          { timeSec: prev.length === 0 ? '0' : '', bpm: '' }
-                        ])}
-                      >+ Add tempo</button>
-                    </div>
-                    <p className="auto-chart-tempo-help">
-                      Leave empty to auto-detect. Add a row with time 0 to override the initial BPM, plus more rows to declare tempo changes at specific timestamps (in seconds). Note positions are retimed to keep audio sync.
-                    </p>
-                    {autoChartTempoEvents.length > 0 && (
-                      <div className="auto-chart-tempo-list">
-                        <div className="auto-chart-tempo-row auto-chart-tempo-row-head">
-                          <span>Time (s)</span>
-                          <span>BPM</span>
-                          <span />
-                        </div>
-                        {autoChartTempoEvents.map((event, index) => (
-                          <div key={index} className="auto-chart-tempo-row">
-                            <input
-                              type="number"
-                              min={0}
-                              step={0.01}
-                              value={event.timeSec}
-                              placeholder="0"
-                              disabled={autoChartProgress.isRunning}
-                              onChange={(e) => {
-                                const v = e.target.value
-                                setAutoChartTempoEvents((prev) => prev.map((row, i) => i === index ? { ...row, timeSec: v } : row))
-                              }}
-                            />
+                  <section className="settings-preferences-group">
+                    <button
+                      type="button"
+                      className="auto-chart-collapse-toggle"
+                      onClick={() => setAutoChartAdvancedOpen((v) => !v)}
+                      aria-expanded={autoChartAdvancedOpen}
+                    >
+                      <span className="auto-chart-collapse-chevron" aria-hidden="true">
+                        <svg viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                          <path
+                            d="M4 2.5L8 6L4 9.5"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+                      </span>
+                      <span>Advanced</span>
+                    </button>
+                    {autoChartAdvancedOpen && (
+                      <div className="settings-preferences-body">
+                        <label className="settings-checkbox-row">
+                          <input
+                            type="checkbox"
+                            checked={autoChartDisableOnlineLookup}
+                            onChange={(event) =>
+                              setAutoChartDisableOnlineLookup(event.target.checked)
+                            }
+                            disabled={autoChartProgress.isRunning}
+                          />
+                          <span>
+                            Offline mode (disable online lookups)
+                            <small style={{ display: 'block', opacity: 0.7 }}>
+                              Skips MusicBrainz, album art, and lyric searches. Use this for custom
+                              uploads to avoid them being misidentified as other songs.
+                            </small>
+                          </span>
+                        </label>
+
+                        <label className="settings-checkbox-row">
+                          <input
+                            type="checkbox"
+                            checked={autoChartDownloadVideo}
+                            onChange={(event) => setAutoChartDownloadVideo(event.target.checked)}
+                            disabled={autoChartProgress.isRunning}
+                          />
+                          <span>
+                            Download video for URL inputs
+                            <small style={{ display: 'block', opacity: 0.7 }}>
+                              After charting finishes, pull the source video (e.g. YouTube) into
+                              each song folder so it plays in the timeline and in-game.
+                            </small>
+                          </span>
+                        </label>
+
+                        <label className="settings-checkbox-row">
+                          <input
+                            type="checkbox"
+                            checked={autoChartKeepStems}
+                            onChange={(event) => setAutoChartKeepStems(event.target.checked)}
+                            disabled={autoChartProgress.isRunning}
+                          />
+                          <span>
+                            Keep separated stems
+                            <small style={{ display: 'block', opacity: 0.7 }}>
+                              Export the separated stems (drums, bass, vocals, etc.) as
+                              per-instrument oggs in each song folder instead of discarding them.
+                              Lets you remix or mute instruments in-game.
+                            </small>
+                          </span>
+                        </label>
+
+                        <label className="settings-checkbox-row">
+                          <input
+                            type="checkbox"
+                            checked={autoChartImproveTempo}
+                            onChange={(event) => setAutoChartImproveTempo(event.target.checked)}
+                            disabled={autoChartProgress.isRunning}
+                          />
+                          <span>
+                            Improve tempo accuracy (recommended)
+                            <small style={{ display: 'block', opacity: 0.7 }}>
+                              Beat-tracks the audio to align the chart&rsquo;s beat and measure
+                              lines to the real performance, so notes stop drifting off the grid.
+                              Follows tempo changes in live recordings while keeping notes in sync
+                              with the audio. Disabled automatically when you set a manual tempo map
+                              below.
+                            </small>
+                          </span>
+                        </label>
+
+                        <div className="auto-chart-bpm-source" style={{ margin: '4px 0 2px' }}>
+                          <label
+                            className="settings-checkbox-row"
+                            style={{ alignItems: 'flex-start' }}
+                          >
+                            <span style={{ flex: 1 }}>
+                              Manual BPM
+                              <small style={{ display: 'block', opacity: 0.7 }}>
+                                Know the song&rsquo;s tempo? Enter it and it&rsquo;s treated as the
+                                truth: the beat grid is locked to this BPM (fixing any wrong-tempo
+                                or octave detection). With &ldquo;Improve tempo accuracy&rdquo; on,
+                                the audio is still beat-tracked to follow drift around this value;
+                                with it off, this exact BPM is applied. Leave blank to detect
+                                automatically.
+                              </small>
+                            </span>
                             <input
                               type="number"
                               min={1}
                               step={0.001}
-                              value={event.bpm}
-                              placeholder="120"
+                              value={autoChartManualBpm}
+                              placeholder="auto"
                               disabled={autoChartProgress.isRunning}
-                              onChange={(e) => {
-                                const v = e.target.value
-                                setAutoChartTempoEvents((prev) => prev.map((row, i) => i === index ? { ...row, bpm: v } : row))
-                              }}
+                              style={{ width: 84, marginLeft: 12 }}
+                              onChange={(event) => setAutoChartManualBpm(event.target.value)}
                             />
+                          </label>
+                        </div>
+
+                        <label className="settings-checkbox-row">
+                          <input
+                            type="checkbox"
+                            checked={autoChartSnapDrums}
+                            onChange={(event) => setAutoChartSnapDrums(event.target.checked)}
+                            disabled={autoChartProgress.isRunning}
+                          />
+                          <span>
+                            Snap drums to grid
+                            <small style={{ display: 'block', opacity: 0.7 }}>
+                              Nudge drum notes that land just off the beat onto the nearest 1/32
+                              grid line, removing the slight timing jitter from onset detection.
+                              Genuinely off-grid hits (fills, syncopation) are left untouched.
+                            </small>
+                          </span>
+                        </label>
+
+                        <div style={{ marginTop: 12 }}>
+                          {autoChartInputTab === 'stems' ? (
+                            <p style={{ fontSize: 12, opacity: 0.7, margin: 0 }}>
+                              Tracks to chart are determined automatically from the stems you
+                              provide on the Stems tab — only instruments with a stem will be
+                              charted.
+                            </p>
+                          ) : (
+                            <>
+                              <div
+                                style={{
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  justifyContent: 'space-between',
+                                  marginBottom: 6
+                                }}
+                              >
+                                <strong style={{ fontSize: 13 }}>Tracks to chart</strong>
+                                <div style={{ display: 'flex', gap: 6 }}>
+                                  <button
+                                    type="button"
+                                    className="settings-modal-secondary"
+                                    style={{ fontSize: 11, padding: '2px 8px' }}
+                                    disabled={autoChartProgress.isRunning}
+                                    onClick={() =>
+                                      setAutoChartEnabledTracks({
+                                        drums: true,
+                                        guitar: true,
+                                        bass: true,
+                                        vocals: true,
+                                        harmonies: true,
+                                        keys: true,
+                                        proKeys: true
+                                      })
+                                    }
+                                  >
+                                    All
+                                  </button>
+                                  <button
+                                    type="button"
+                                    className="settings-modal-secondary"
+                                    style={{ fontSize: 11, padding: '2px 8px' }}
+                                    disabled={autoChartProgress.isRunning}
+                                    onClick={() =>
+                                      setAutoChartEnabledTracks({
+                                        drums: false,
+                                        guitar: false,
+                                        bass: false,
+                                        vocals: false,
+                                        harmonies: false,
+                                        keys: false,
+                                        proKeys: false
+                                      })
+                                    }
+                                  >
+                                    None
+                                  </button>
+                                </div>
+                              </div>
+                              <p style={{ fontSize: 12, opacity: 0.7, margin: '0 0 8px' }}>
+                                Uncheck any track you do not want STRUM to generate. All are charted
+                                by default.
+                              </p>
+                              <div
+                                style={{
+                                  display: 'grid',
+                                  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+                                  gap: '6px 16px'
+                                }}
+                              >
+                                {(
+                                  [
+                                    { key: 'drums', label: 'Drums' },
+                                    { key: 'guitar', label: 'Guitar' },
+                                    { key: 'bass', label: 'Bass' },
+                                    { key: 'keys', label: 'Keys' },
+                                    { key: 'proKeys', label: 'Pro Keys' },
+                                    { key: 'vocals', label: 'Vocals' },
+                                    { key: 'harmonies', label: 'Vocal Harmonies (HARM2/3)' }
+                                  ] as const
+                                ).map((track) => (
+                                  <label
+                                    key={track.key}
+                                    className="settings-checkbox-row"
+                                    style={{ margin: 0 }}
+                                  >
+                                    <input
+                                      type="checkbox"
+                                      checked={autoChartEnabledTracks[track.key]}
+                                      disabled={
+                                        autoChartProgress.isRunning ||
+                                        (track.key === 'harmonies' &&
+                                          !autoChartEnabledTracks.vocals)
+                                      }
+                                      onChange={(event) =>
+                                        setAutoChartEnabledTracks((prev) => {
+                                          const next = {
+                                            ...prev,
+                                            [track.key]: event.target.checked
+                                          }
+                                          // Disabling vocals also disables harmonies.
+                                          if (track.key === 'vocals' && !event.target.checked)
+                                            next.harmonies = false
+                                          return next
+                                        })
+                                      }
+                                    />
+                                    <span>{track.label}</span>
+                                  </label>
+                                ))}
+                              </div>
+                            </>
+                          )}
+                        </div>
+
+                        <div className="auto-chart-tempo-override">
+                          <div className="auto-chart-tempo-header">
+                            <strong>Tempo override</strong>
                             <button
                               type="button"
-                              className="auto-chart-tempo-remove"
-                              title="Remove"
+                              className="settings-modal-secondary"
+                              style={{ fontSize: 11, padding: '2px 8px' }}
                               disabled={autoChartProgress.isRunning}
-                              onClick={() => setAutoChartTempoEvents((prev) => prev.filter((_, i) => i !== index))}
-                            >×</button>
+                              onClick={() =>
+                                setAutoChartTempoEvents((prev) => [
+                                  ...prev,
+                                  { timeSec: prev.length === 0 ? '0' : '', bpm: '' }
+                                ])
+                              }
+                            >
+                              + Add tempo
+                            </button>
                           </div>
-                        ))}
+                          <p className="auto-chart-tempo-help">
+                            Leave empty to auto-detect. Add a row with time 0 to override the
+                            initial BPM, plus more rows to declare tempo changes at specific
+                            timestamps (in seconds). Note positions are retimed to keep audio sync.
+                          </p>
+                          {autoChartTempoEvents.length > 0 && (
+                            <div className="auto-chart-tempo-list">
+                              <div className="auto-chart-tempo-row auto-chart-tempo-row-head">
+                                <span>Time (s)</span>
+                                <span>BPM</span>
+                                <span />
+                              </div>
+                              {autoChartTempoEvents.map((event, index) => (
+                                <div key={index} className="auto-chart-tempo-row">
+                                  <input
+                                    type="number"
+                                    min={0}
+                                    step={0.01}
+                                    value={event.timeSec}
+                                    placeholder="0"
+                                    disabled={autoChartProgress.isRunning}
+                                    onChange={(e) => {
+                                      const v = e.target.value
+                                      setAutoChartTempoEvents((prev) =>
+                                        prev.map((row, i) =>
+                                          i === index ? { ...row, timeSec: v } : row
+                                        )
+                                      )
+                                    }}
+                                  />
+                                  <input
+                                    type="number"
+                                    min={1}
+                                    step={0.001}
+                                    value={event.bpm}
+                                    placeholder="120"
+                                    disabled={autoChartProgress.isRunning}
+                                    onChange={(e) => {
+                                      const v = e.target.value
+                                      setAutoChartTempoEvents((prev) =>
+                                        prev.map((row, i) =>
+                                          i === index ? { ...row, bpm: v } : row
+                                        )
+                                      )
+                                    }}
+                                  />
+                                  <button
+                                    type="button"
+                                    className="auto-chart-tempo-remove"
+                                    title="Remove"
+                                    disabled={autoChartProgress.isRunning}
+                                    onClick={() =>
+                                      setAutoChartTempoEvents((prev) =>
+                                        prev.filter((_, i) => i !== index)
+                                      )
+                                    }
+                                  >
+                                    ×
+                                  </button>
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                        </div>
                       </div>
                     )}
-                  </div>
-                </div>
-                )}
-              </section>
-              </>
+                  </section>
+                </>
               )}
 
               <section className="settings-preferences-group">
@@ -1662,15 +2294,20 @@ export function Toolbar(): React.JSX.Element {
                     <span>{autoChartProgress.percent}%</span>
                   </div>
                   <div className="toolbar-updater-bar auto-chart-progress-bar">
-                    <div className="toolbar-updater-bar-fill" style={{ width: `${autoChartProgress.percent}%` }} />
+                    <div
+                      className="toolbar-updater-bar-fill"
+                      style={{ width: `${autoChartProgress.percent}%` }}
+                    />
                   </div>
                   <div className="auto-chart-progress-message">
                     {autoChartCloseCountdown !== null
                       ? `All songs auto-charted. Closing in ${autoChartCloseCountdown}…`
-                      : (autoChartProgress.message || 'Idle')}
+                      : autoChartProgress.message || 'Idle'}
                   </div>
                   {autoChartProgress.currentItem && (
-                    <div className="auto-chart-progress-subtle">Current: {autoChartProgress.currentItem}</div>
+                    <div className="auto-chart-progress-subtle">
+                      Current: {autoChartProgress.currentItem}
+                    </div>
                   )}
                   {autoChartProgress.error && (
                     <div className="auto-chart-error">
@@ -1690,7 +2327,9 @@ export function Toolbar(): React.JSX.Element {
                   {autoChartProgress.warnings.length > 0 && (
                     <div className="auto-chart-warning-list">
                       {autoChartProgress.warnings.map((warning) => (
-                        <div key={warning} className="auto-chart-warning-item">{warning}</div>
+                        <div key={warning} className="auto-chart-warning-item">
+                          {warning}
+                        </div>
                       ))}
                     </div>
                   )}
@@ -1700,31 +2339,47 @@ export function Toolbar(): React.JSX.Element {
 
             <div className="settings-modal-footer">
               {!autoChartProgress.isRunning && (
-                <button className="settings-modal-secondary" onClick={() => {
-                  setAutoChartCloseCountdown(null)
-                  setAutoChartFiles([])
-                  setAutoChartFolders([])
-                  setAutoChartStemFolders([])
-                  setAutoChartStemSongs([makeEmptyStemSong()])
-                  setAutoChartUrls([EMPTY_AUTO_CHART_URL])
-                  setAutoChartErrorCopied(false)
-                  setAutoChartProgress({
-                    runId: null,
-                    stage: 'bootstrap',
-                    message: '',
-                    percent: 0,
-                    isRunning: false,
-                    outputDir: getPreferredAutoChartOutputDir(),
-                    error: null,
-                    warnings: []
-                  })
-                }}>Reset</button>
+                <button
+                  className="settings-modal-secondary"
+                  onClick={() => {
+                    setAutoChartCloseCountdown(null)
+                    setAutoChartFiles([])
+                    setAutoChartFolders([])
+                    setAutoChartStemFolders([])
+                    setAutoChartStemSongs([makeEmptyStemSong()])
+                    setAutoChartUrls([EMPTY_AUTO_CHART_URL])
+                    setAutoChartErrorCopied(false)
+                    setAutoChartProgress({
+                      runId: null,
+                      stage: 'bootstrap',
+                      message: '',
+                      percent: 0,
+                      isRunning: false,
+                      outputDir: getPreferredAutoChartOutputDir(),
+                      error: null,
+                      warnings: []
+                    })
+                  }}
+                >
+                  Reset
+                </button>
               )}
-              <button className="settings-modal-secondary" onClick={() => autoChartProgress.isRunning ? void handleCancelAutoChart() : setIsAutoChartModalOpen(false)}>
+              <button
+                className="settings-modal-secondary"
+                onClick={() =>
+                  autoChartProgress.isRunning
+                    ? void handleCancelAutoChart()
+                    : setIsAutoChartModalOpen(false)
+                }
+              >
                 {autoChartProgress.isRunning ? 'Cancel Run' : 'Close'}
               </button>
               {!autoChartProgress.isRunning && (
-                <button className="settings-modal-primary" onClick={() => void handleStartAutoChart()} disabled={runtimeStatus?.managed === true && !runtimeStatus.ready}>
+                <button
+                  className="settings-modal-primary"
+                  onClick={() => void handleStartAutoChart()}
+                  disabled={runtimeStatus?.managed === true && !runtimeStatus.ready}
+                >
                   Start Auto-Chart
                 </button>
               )}
@@ -1741,7 +2396,11 @@ export function Toolbar(): React.JSX.Element {
 
 // Stem mixer popover button — lets the user mute/solo individual audio
 // stems (drums.ogg, bass.ogg, vocals.ogg, etc.) loaded for the song.
-function StemMixerButton({ activeSongId }: { activeSongId: string | null }): React.JSX.Element | null {
+function StemMixerButton({
+  activeSongId
+}: {
+  activeSongId: string | null
+}): React.JSX.Element | null {
   const [open, setOpen] = useState(false)
   const [stems, setStems] = useState<audioService.StemControl[]>([])
   const [popoverPos, setPopoverPos] = useState<{ top: number; right: number } | null>(null)
@@ -1749,6 +2408,7 @@ function StemMixerButton({ activeSongId }: { activeSongId: string | null }): Rea
 
   useEffect(() => {
     if (!activeSongId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setStems([])
       return
     }
@@ -1790,9 +2450,33 @@ function StemMixerButton({ activeSongId }: { activeSongId: string | null }): Rea
         aria-label="Stem mixer"
       >
         <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <line x1="3" y1="2" x2="3" y2="14" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-          <line x1="8" y1="2" x2="8" y2="14" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-          <line x1="13" y1="2" x2="13" y2="14" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+          <line
+            x1="3"
+            y1="2"
+            x2="3"
+            y2="14"
+            stroke="currentColor"
+            strokeWidth="1.4"
+            strokeLinecap="round"
+          />
+          <line
+            x1="8"
+            y1="2"
+            x2="8"
+            y2="14"
+            stroke="currentColor"
+            strokeWidth="1.4"
+            strokeLinecap="round"
+          />
+          <line
+            x1="13"
+            y1="2"
+            x2="13"
+            y2="14"
+            stroke="currentColor"
+            strokeWidth="1.4"
+            strokeLinecap="round"
+          />
           <rect x="1.5" y="9" width="3" height="3" rx="0.6" fill="currentColor" />
           <rect x="6.5" y="4" width="3" height="3" rx="0.6" fill="currentColor" />
           <rect x="11.5" y="7" width="3" height="3" rx="0.6" fill="currentColor" />
@@ -1805,7 +2489,9 @@ function StemMixerButton({ activeSongId }: { activeSongId: string | null }): Rea
         >
           <div className="stem-mixer-header">
             <span>Stem Mixer</span>
-            <button className="stem-mixer-close" onClick={() => setOpen(false)} aria-label="Close">×</button>
+            <button className="stem-mixer-close" onClick={() => setOpen(false)} aria-label="Close">
+              ×
+            </button>
           </div>
           {stems.length === 0 ? (
             <div className="stem-mixer-empty">No stems loaded.</div>
@@ -1840,7 +2526,11 @@ function StemMixerButton({ activeSongId }: { activeSongId: string | null }): Rea
                       step={0.01}
                       value={s.volume}
                       onChange={(e) =>
-                        audioService.setStemVolume(activeSongId, s.filePath, parseFloat(e.target.value))
+                        audioService.setStemVolume(
+                          activeSongId,
+                          s.filePath,
+                          parseFloat(e.target.value)
+                        )
                       }
                       className="toolbar-volume-slider stem-mixer-volume-slider"
                       title={`Volume: ${Math.round(s.volume * 100)}%`}

--- a/src/renderer/src/components/ValidationPreviewCard.tsx
+++ b/src/renderer/src/components/ValidationPreviewCard.tsx
@@ -1,0 +1,1182 @@
+import React, { useMemo, useState, useEffect, useCallback } from 'react'
+import type { ValidationIssue, SongData, Note, Instrument, Difficulty } from '../types'
+import { getSongStore, useSettingsStore, useUIStore } from '../stores'
+import {
+  validateChartAsync,
+  tickToMs,
+  getDrumHandAssignments,
+  isHandHit,
+  getDrumLaneIndex,
+  getDrumTransitionLimit
+} from '../utils/chartValidation'
+
+interface Props {
+  issue: ValidationIssue
+  song: SongData
+  activeSongId: string
+}
+
+interface QuickSuggestion {
+  label: string
+  action: () => Note[]
+}
+
+const W = 800
+const H = 95
+
+const getIssueTypeKey = (issue: ValidationIssue): string => {
+  const msg = issue.message.toLowerCase()
+  if (msg.includes('overlapping')) return 'overlapping'
+  if (msg.includes('crossover')) return 'crossover'
+  if (msg.includes('transition')) return 'transition'
+  if (msg.includes('simultaneous hand')) return 'simultaneous'
+  if (msg.includes('sustain')) return 'sustain'
+  return 'other'
+}
+
+function GridCell({
+  x,
+  y,
+  laneColor,
+  existingNote,
+  onToggle
+}: {
+  x: number
+  y: number
+  laneColor: string
+  existingNote: Note | undefined
+  onToggle: () => void
+}): React.JSX.Element {
+  const [hovered, setHovered] = React.useState(false)
+
+  return (
+    <circle
+      cx={x}
+      cy={y}
+      r={existingNote ? 5.5 : 4}
+      fill={existingNote ? laneColor : hovered ? laneColor : 'transparent'}
+      stroke={hovered ? '#ffffff' : existingNote ? 'rgba(255,255,255,0.4)' : 'transparent'}
+      strokeWidth={hovered || existingNote ? 1.5 : 0}
+      opacity={existingNote ? 1.0 : hovered ? 0.6 : 0.03}
+      cursor="pointer"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onClick={(e) => {
+        e.stopPropagation()
+        onToggle()
+      }}
+      style={{
+        transition: 'all 0.1s ease',
+        filter: existingNote ? `drop-shadow(0 0 3px ${laneColor})` : 'none'
+      }}
+    />
+  )
+}
+
+export function ValidationPreviewCard({ issue, song, activeSongId }: Props): React.JSX.Element {
+  const tick = issue.tick ?? 0
+  const instrument = issue.instrument ?? 'drums'
+  const difficulty = issue.difficulty ?? 'expert'
+  const isVocals = instrument === 'vocals'
+  const songStore = getSongStore(activeSongId)
+
+  // Find all notes of this instrument/difficulty in the entire song to compute dynamic preview window
+  const instrumentNotes = useMemo(() => {
+    if (isVocals) {
+      return song.vocalNotes || []
+    } else {
+      return (song.notes || []).filter(
+        (n) => n.instrument === instrument && n.difficulty === difficulty
+      )
+    }
+  }, [song, instrument, difficulty, isVocals])
+
+  // Dynamically load enough ticks to visualize at least 3 notes in either direction with buffer
+  const { startTick, endTick } = useMemo(() => {
+    const notesBefore = instrumentNotes.filter((n) => n.tick < tick).sort((a, b) => b.tick - a.tick)
+    const notesAfter = instrumentNotes.filter((n) => n.tick > tick).sort((a, b) => a.tick - b.tick)
+
+    let maxDiff = 1440 // Minimum half-window size (1440 ticks = 12 snap intervals)
+
+    // Visualize at least 3 notes in the left direction
+    if (notesBefore.length >= 3) {
+      const thirdNoteTick = notesBefore[2].tick
+      const diff = tick - thirdNoteTick + 240
+      if (diff > maxDiff) {
+        maxDiff = diff
+      }
+    } else if (notesBefore.length > 0) {
+      const firstNoteTick = notesBefore[notesBefore.length - 1].tick
+      const diff = tick - firstNoteTick + 240
+      if (diff > maxDiff) {
+        maxDiff = diff
+      }
+    }
+
+    // Visualize at least 3 notes in the right direction
+    if (notesAfter.length >= 3) {
+      const thirdNoteTick = notesAfter[2].tick
+      const diff = thirdNoteTick - tick + 240
+      if (diff > maxDiff) {
+        maxDiff = diff
+      }
+    } else if (notesAfter.length > 0) {
+      const lastNoteTick = notesAfter[notesAfter.length - 1].tick
+      const diff = lastNoteTick - tick + 240
+      if (diff > maxDiff) {
+        maxDiff = diff
+      }
+    }
+
+    // Align half-width to the nearest 120-tick boundary (1/16 note snap grid step)
+    const halfWidth = Math.ceil(maxDiff / 120) * 120
+    return { startTick: tick - halfWidth, endTick: tick + halfWidth }
+  }, [instrumentNotes, tick])
+
+  // Filter notes to the computed dynamic preview window
+  const windowNotes = useMemo(() => {
+    return instrumentNotes.filter((n) => n.tick >= startTick && n.tick <= endTick)
+  }, [instrumentNotes, startTick, endTick])
+
+  // Local draft notes for the sandbox view
+  const [draftNotes, setDraftNotes] = useState<Note[]>(() => [...windowNotes])
+
+  // Keep draft in sync with song updates if the user doesn't have an unsaved draft
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setDraftNotes([...windowNotes])
+  }, [windowNotes])
+
+  const hasActiveDraft = useMemo(() => {
+    if (draftNotes.length !== windowNotes.length) return true
+    return draftNotes.some((dn) => {
+      const wn = windowNotes.find((w) => w.id === dn.id)
+      if (!wn) return true
+      return (
+        wn.tick !== dn.tick ||
+        wn.lane !== dn.lane ||
+        wn.duration !== dn.duration ||
+        wn.velocity !== dn.velocity ||
+        JSON.stringify(wn.flags) !== JSON.stringify(dn.flags)
+      )
+    })
+  }, [draftNotes, windowNotes])
+
+  const handleRevert = (): void => {
+    setDraftNotes([...windowNotes])
+  }
+
+  const lanes = useMemo(() => {
+    if (instrument === 'drums') {
+      return [
+        'kick',
+        'doubleKick',
+        'snare',
+        'yellowTom',
+        'yellowCymbal',
+        'blueTom',
+        'blueCymbal',
+        'greenTom',
+        'greenCymbal'
+      ]
+    }
+    if (instrument === 'guitar' || instrument === 'bass') {
+      return ['open', 'green', 'red', 'yellow', 'blue', 'orange']
+    }
+    return []
+  }, [instrument])
+
+  const getLaneIndex = useCallback(
+    (note: Note): number => {
+      if (instrument === 'drums') {
+        if (String(note.lane) === 'kick') {
+          return note.flags?.isDoubleKick ? 1 : 0
+        }
+        const idx = lanes.indexOf(String(note.lane))
+        return idx !== -1 ? idx : -1
+      }
+      return lanes.indexOf(String(note.lane))
+    },
+    [instrument, lanes]
+  )
+
+  const pitchRange = useMemo((): { min: number; max: number } => {
+    if (draftNotes.length === 0) return { min: 60, max: 60 }
+    let min = Infinity
+    let max = -Infinity
+    for (const n of draftNotes) {
+      const pitch = typeof n.lane === 'number' ? n.lane : 60
+      if (pitch < min) min = pitch
+      if (pitch > max) max = pitch
+    }
+    return { min, max }
+  }, [draftNotes])
+
+  const getNoteY = useCallback(
+    (note: Note): number => {
+      if (lanes.length > 0) {
+        const idx = getLaneIndex(note)
+        if (idx === -1) return H / 2
+        const padding = 10
+        const spacing = (H - padding * 2) / (lanes.length - 1)
+        return padding + idx * spacing
+      } else {
+        const { min, max } = pitchRange
+        if (min === max) return H / 2
+        const padding = 12
+        const pct = ((typeof note.lane === 'number' ? note.lane : 60) - min) / (max - min)
+        return padding + (1 - pct) * (H - padding * 2)
+      }
+    },
+    [lanes, pitchRange, getLaneIndex]
+  )
+
+  // Setup snap divisions for interactive timeline cells (1/16 beat intervals in dynamic window)
+  const snapTicks = useMemo(() => {
+    const list: number[] = []
+    for (let t = startTick; t <= endTick; t += 120) {
+      list.push(t)
+    }
+    return list
+  }, [startTick, endTick])
+
+  const pixelsPerTick = W / (endTick - startTick)
+
+  const verticalGridLines = useMemo(() => {
+    return snapTicks.map((t) => {
+      const x = (t - startTick) * pixelsPerTick
+      const isCenter = t === tick
+      return (
+        <line
+          key={t}
+          x1={x}
+          y1={0}
+          x2={x}
+          y2={H}
+          stroke={isCenter ? '#ff4d4d' : '#222230'}
+          strokeWidth={isCenter ? 1.5 : 1}
+          strokeDasharray={isCenter ? '3,3' : 'none'}
+          opacity={isCenter ? 0.8 : 0.4}
+        />
+      )
+    })
+  }, [snapTicks, startTick, pixelsPerTick, tick])
+
+  const backgroundLines = useMemo(() => {
+    if (lanes.length > 0) {
+      return lanes.map((lane, idx) => {
+        const padding = 10
+        const spacing = (H - padding * 2) / (lanes.length - 1)
+        const y = padding + idx * spacing
+
+        let label = ''
+        if (instrument === 'drums') {
+          if (lane === 'kick') label = 'K'
+          else if (lane === 'doubleKick') label = '2K'
+          else if (lane === 'snare') label = 'S'
+          else if (lane === 'yellowTom') label = 'YT'
+          else if (lane === 'yellowCymbal') label = 'YC'
+          else if (lane === 'blueTom') label = 'BT'
+          else if (lane === 'blueCymbal') label = 'BC'
+          else if (lane === 'greenTom') label = 'GT'
+          else if (lane === 'greenCymbal') label = 'GC'
+        } else if (instrument === 'guitar' || instrument === 'bass') {
+          if (lane === 'open') label = 'O'
+          else if (lane === 'green') label = 'G'
+          else if (lane === 'red') label = 'R'
+          else if (lane === 'yellow') label = 'Y'
+          else if (lane === 'blue') label = 'B'
+          else if (lane === 'orange') label = 'O'
+        }
+
+        return (
+          <g key={lane}>
+            <line x1="0" y1={y} x2={W} y2={y} stroke="#2a2a3a" strokeWidth="1" />
+            <text
+              x="4"
+              y={y + 3}
+              fill="#555577"
+              fontSize="8"
+              fontFamily="monospace"
+              fontWeight="bold"
+            >
+              {label}
+            </text>
+          </g>
+        )
+      })
+    } else {
+      return [0.25, 0.5, 0.75].map((pct, idx) => {
+        const y = 12 + pct * (H - 24)
+        return <line key={idx} x1="0" y1={y} x2={W} y2={y} stroke="#2a2a3a" strokeWidth="1" />
+      })
+    }
+  }, [lanes, instrument])
+
+  const renderedNotes = draftNotes.map((note) => {
+    const noteX = (note.tick - startTick) * pixelsPerTick
+    const noteY = getNoteY(note)
+
+    let color = '#9b59b6'
+    if (instrument === 'guitar' || instrument === 'bass') {
+      if (note.lane === 'green') color = '#79D304'
+      else if (note.lane === 'red') color = '#FF1D23'
+      else if (note.lane === 'yellow') color = '#FFE900'
+      else if (note.lane === 'blue') color = '#00BFFF'
+      else if (note.lane === 'orange') color = '#FF8400'
+      else if (note.lane === 'open') color = '#C800FF'
+    } else if (instrument === 'drums') {
+      const laneStr = String(note.lane)
+      if (laneStr === 'kick') color = note.flags?.isDoubleKick ? '#B85100' : '#FF8400'
+      else if (laneStr === 'snare') color = '#FF1D23'
+      else if (laneStr === 'yellowTom') color = '#FFE900'
+      else if (laneStr === 'yellowCymbal') color = '#FFE900'
+      else if (laneStr === 'blueTom') color = '#00BFFF'
+      else if (laneStr === 'blueCymbal') color = '#00BFFF'
+      else if (laneStr === 'greenTom') color = '#79D304'
+      else if (laneStr === 'greenCymbal') color = '#79D304'
+    }
+
+    const isSustain = note.duration > 0
+    const tailW = note.duration * pixelsPerTick
+
+    return (
+      <g key={note.id}>
+        {isSustain && (
+          <line
+            x1={noteX}
+            y1={noteY}
+            x2={noteX + tailW}
+            y2={noteY}
+            stroke={color}
+            strokeWidth="4"
+            opacity="0.5"
+            strokeLinecap="round"
+          />
+        )}
+      </g>
+    )
+  })
+
+  const handleToggleDraftNote = useCallback(
+    (lane: string, t: number): void => {
+      if (isVocals) return
+      setDraftNotes((prev: Note[]): Note[] => {
+        const existingIdx = prev.findIndex((n) => {
+          if (n.tick !== t) return false
+          if (lane === 'doubleKick') {
+            return String(n.lane) === 'kick' && !!n.flags?.isDoubleKick
+          }
+          if (lane === 'kick') {
+            return String(n.lane) === 'kick' && !n.flags?.isDoubleKick
+          }
+          return String(n.lane) === lane
+        })
+
+        if (existingIdx !== -1) {
+          return prev.filter((_, idx) => idx !== existingIdx)
+        } else {
+          const isCym = lane === 'yellowCymbal' || lane === 'blueCymbal' || lane === 'greenCymbal'
+          const isDouble = lane === 'doubleKick'
+
+          const newNote: Note = {
+            id: `draft-${Math.random().toString(36).substring(2, 11)}`,
+            tick: t,
+            duration: 0,
+            instrument: instrument as Instrument,
+            difficulty: difficulty as Difficulty,
+            lane: (isDouble ? 'kick' : lane) as Note['lane'],
+            velocity: 100,
+            flags: isDouble ? { isDoubleKick: true } : isCym ? { isCymbal: true } : undefined
+          }
+          return [...prev, newNote]
+        }
+      })
+    },
+    [isVocals, instrument, difficulty]
+  )
+
+  // Interactive grid elements
+  const gridCells = useMemo(() => {
+    const cells: React.JSX.Element[] = []
+    if (lanes.length === 0) return cells
+
+    for (const lane of lanes) {
+      const idx = lanes.indexOf(lane)
+      const padding = 10
+      const spacing = (H - padding * 2) / (lanes.length - 1)
+      const y = padding + idx * spacing
+
+      let laneColor = '#888888'
+      if (instrument === 'guitar' || instrument === 'bass') {
+        if (lane === 'green') laneColor = '#79D304'
+        else if (lane === 'red') laneColor = '#FF1D23'
+        else if (lane === 'yellow') laneColor = '#FFE900'
+        else if (lane === 'blue') laneColor = '#00BFFF'
+        else if (lane === 'orange') laneColor = '#FF8400'
+        else if (lane === 'open') laneColor = '#C800FF'
+      } else if (instrument === 'drums') {
+        if (lane === 'kick') laneColor = '#FF8400'
+        else if (lane === 'doubleKick') laneColor = '#B85100'
+        else if (lane === 'snare') laneColor = '#FF1D23'
+        else if (lane === 'yellowTom') laneColor = '#FFE900'
+        else if (lane === 'yellowCymbal') laneColor = '#FFE900'
+        else if (lane === 'blueTom') laneColor = '#00BFFF'
+        else if (lane === 'blueCymbal') laneColor = '#00BFFF'
+        else if (lane === 'greenTom') laneColor = '#79D304'
+        else if (lane === 'greenCymbal') laneColor = '#79D304'
+      }
+
+      for (const t of snapTicks) {
+        const x = (t - startTick) * pixelsPerTick
+
+        const existingNote = draftNotes.find((n) => {
+          if (n.tick !== t) return false
+          if (lane === 'doubleKick') {
+            return String(n.lane) === 'kick' && !!n.flags?.isDoubleKick
+          }
+          if (lane === 'kick') {
+            return String(n.lane) === 'kick' && !n.flags?.isDoubleKick
+          }
+          return String(n.lane) === lane
+        })
+
+        cells.push(
+          <GridCell
+            key={`${lane}-${t}`}
+            x={x}
+            y={y}
+            laneColor={laneColor}
+            existingNote={existingNote}
+            onToggle={() => handleToggleDraftNote(lane, t)}
+          />
+        )
+      }
+    }
+
+    return cells
+  }, [lanes, draftNotes, snapTicks, startTick, pixelsPerTick, instrument, handleToggleDraftNote])
+
+  // --- Drum Hands and Path Calculations ---
+  const handNotes = useMemo(() => {
+    if (instrument !== 'drums') return []
+    return draftNotes.filter(isHandHit).sort((a, b) => a.tick - b.tick)
+  }, [draftNotes, instrument])
+
+  const noteAssignments = useMemo(() => {
+    if (instrument !== 'drums' || handNotes.length === 0) return new Map<string, 'LH' | 'RH'>()
+    return getDrumHandAssignments(handNotes, song.tempoEvents)
+  }, [handNotes, instrument, song.tempoEvents])
+
+  const checkIsViolating = useCallback(
+    (nA: Note, nB: Note): boolean => {
+      const dt = tickToMs(nB.tick, song.tempoEvents) - tickToMs(nA.tick, song.tempoEvents)
+      if (dt >= 200) return false
+
+      const settings = useSettingsStore.getState()
+      const { limit } = getDrumTransitionLimit(nA, nB, settings)
+      if (limit === 0) return false
+
+      return dt < limit - 1
+    },
+    [song.tempoEvents]
+  )
+
+  const handPaths = useMemo(() => {
+    if (instrument !== 'drums') return null
+
+    const lhNotes = handNotes.filter((n) => noteAssignments.get(n.id) === 'LH')
+    const rhNotes = handNotes.filter((n) => noteAssignments.get(n.id) === 'RH')
+
+    const lines: React.JSX.Element[] = []
+
+    // Left hand path (Blue / Cyan)
+    for (let i = 1; i < lhNotes.length; i++) {
+      const nA = lhNotes[i - 1]
+      const nB = lhNotes[i]
+      const x1 = (nA.tick - startTick) * pixelsPerTick
+      const y1 = getNoteY(nA)
+      const x2 = (nB.tick - startTick) * pixelsPerTick
+      const y2 = getNoteY(nB)
+      const isViolating = checkIsViolating(nA, nB)
+
+      lines.push(
+        <line
+          key={`lh-${nA.id}-${nB.id}`}
+          x1={x1}
+          y1={y1}
+          x2={x2}
+          y2={y2}
+          stroke={isViolating ? '#ff4d4d' : '#00BFFF'}
+          strokeWidth="2.5"
+          opacity="0.65"
+          markerEnd={isViolating ? 'url(#arrow-red)' : 'url(#arrow-lh)'}
+        />
+      )
+    }
+
+    // Right hand path (Green)
+    for (let i = 1; i < rhNotes.length; i++) {
+      const nA = rhNotes[i - 1]
+      const nB = rhNotes[i]
+      const x1 = (nA.tick - startTick) * pixelsPerTick
+      const y1 = getNoteY(nA)
+      const x2 = (nB.tick - startTick) * pixelsPerTick
+      const y2 = getNoteY(nB)
+      const isViolating = checkIsViolating(nA, nB)
+
+      lines.push(
+        <line
+          key={`rh-${nA.id}-${nB.id}`}
+          x1={x1}
+          y1={y1}
+          x2={x2}
+          y2={y2}
+          stroke={isViolating ? '#ff4d4d' : '#79D304'}
+          strokeWidth="2.5"
+          opacity="0.65"
+          markerEnd={isViolating ? 'url(#arrow-red)' : 'url(#arrow-rh)'}
+        />
+      )
+    }
+
+    return lines
+  }, [
+    handNotes,
+    noteAssignments,
+    instrument,
+    startTick,
+    pixelsPerTick,
+    song.tempoEvents,
+    getNoteY,
+    checkIsViolating
+  ])
+
+  const svgDefs = useMemo(
+    () => (
+      <defs>
+        <marker
+          id="arrow-lh"
+          viewBox="0 0 10 10"
+          refX="8"
+          refY="5"
+          markerWidth="5"
+          markerHeight="5"
+          orient="auto-start-reverse"
+        >
+          <path d="M 0 1.5 L 10 5 L 0 8.5 z" fill="#00BFFF" />
+        </marker>
+        <marker
+          id="arrow-rh"
+          viewBox="0 0 10 10"
+          refX="8"
+          refY="5"
+          markerWidth="5"
+          markerHeight="5"
+          orient="auto-start-reverse"
+        >
+          <path d="M 0 1.5 L 10 5 L 0 8.5 z" fill="#79D304" />
+        </marker>
+        <marker
+          id="arrow-red"
+          viewBox="0 0 10 10"
+          refX="8"
+          refY="5"
+          markerWidth="5"
+          markerHeight="5"
+          orient="auto-start-reverse"
+        >
+          <path d="M 0 1.5 L 10 5 L 0 8.5 z" fill="#ff4d4d" />
+        </marker>
+      </defs>
+    ),
+    []
+  )
+
+  // Run validation checks locally on the draftNotes sandbox
+  const [isDraftValid, setIsDraftValid] = useState(true)
+
+  useEffect(() => {
+    let active = true
+    const checkValidity = async (): Promise<void> => {
+      try {
+        const nonWindowNotes = (song.notes || []).filter(
+          (n) =>
+            !(
+              n.instrument === instrument &&
+              n.difficulty === difficulty &&
+              n.tick >= startTick &&
+              n.tick <= endTick
+            )
+        )
+        const combinedNotes = [...nonWindowNotes, ...draftNotes]
+        const dummySong = { ...song, notes: combinedNotes }
+
+        const settings = useSettingsStore.getState()
+        const issues = await validateChartAsync(dummySong, settings)
+
+        if (!active) return
+
+        // Check if the specific issue that this card represents is resolved
+        const stillHasThisIssue = issues.some(
+          (i) =>
+            i.tick === tick &&
+            i.instrument === instrument &&
+            i.difficulty === difficulty &&
+            getIssueTypeKey(i) === getIssueTypeKey(issue)
+        )
+        setIsDraftValid(!stillHasThisIssue)
+      } catch (err) {
+        console.error('[isDraftValid check failed]', err)
+        if (active) {
+          setIsDraftValid(false)
+        }
+      }
+    }
+
+    checkValidity()
+    return () => {
+      active = false
+    }
+  }, [draftNotes, song, startTick, endTick, instrument, difficulty])
+
+  // Generate quick suggestions
+  const suggestions = useMemo<QuickSuggestion[]>(() => {
+    const list: QuickSuggestion[] = []
+
+    if (issue.message.toLowerCase().includes('simultaneous hand hits')) {
+      const handNotes = draftNotes.filter((n) => n.tick === tick && isHandHit(n))
+
+      if (handNotes.length >= 3) {
+        for (let i = 0; i < handNotes.length; i++) {
+          for (let j = i + 1; j < handNotes.length; j++) {
+            const n1 = handNotes[i]
+            const n2 = handNotes[j]
+            const label = `Keep only ${n1.lane} & ${n2.lane}`
+
+            list.push({
+              label,
+              action: () => {
+                return draftNotes.filter(
+                  (n) => n.tick !== tick || !isHandHit(n) || n.id === n1.id || n.id === n2.id
+                )
+              }
+            })
+          }
+        }
+      }
+    } else if (
+      issue.message.toLowerCase().includes('impossible crossover') ||
+      issue.message.toLowerCase().includes('impossible transition')
+    ) {
+      const notesAtTick = draftNotes.filter((n) => n.tick === tick && isHandHit(n))
+      const prevTicks = Array.from(new Set(draftNotes.map((n) => n.tick)))
+        .filter((t) => t < tick)
+        .sort((a, b) => b - a)
+
+      if (prevTicks.length > 0) {
+        const prevTick = prevTicks[0]
+        const notesAtPrev = draftNotes.filter((n) => n.tick === prevTick && isHandHit(n))
+
+        for (const n2 of notesAtTick) {
+          for (const n1 of notesAtPrev) {
+            const l1 = getDrumLaneIndex(n1)
+            const l2 = getDrumLaneIndex(n2)
+            if (l1 === -1 || l2 === -1 || l1 === l2) continue
+
+            list.push({
+              label: `Make roll: change ${n2.lane} to ${n1.lane}`,
+              action: () => {
+                return draftNotes.map((n) =>
+                  n.id === n2.id ? { ...n, lane: n1.lane, flags: n1.flags } : n
+                )
+              }
+            })
+
+            list.push({
+              label: `Make roll: change ${n1.lane} to ${n2.lane}`,
+              action: () => {
+                return draftNotes.map((n) =>
+                  n.id === n1.id ? { ...n, lane: n2.lane, flags: n2.flags } : n
+                )
+              }
+            })
+          }
+        }
+      }
+
+      for (const note of notesAtTick) {
+        list.push({
+          label: `Delete ${note.lane}`,
+          action: () => {
+            return draftNotes.filter((n) => n.id !== note.id)
+          }
+        })
+      }
+    } else if (issue.message.toLowerCase().includes('overlapping note')) {
+      const overlapping = draftNotes.filter((n) => n.tick === tick)
+      const laneGroups = new Map<string | number, Note[]>()
+      for (const n of overlapping) {
+        let arr = laneGroups.get(n.lane)
+        if (!arr) {
+          arr = []
+          laneGroups.set(n.lane, arr)
+        }
+        arr.push(n)
+      }
+
+      for (const [lane, notesInLane] of laneGroups.entries()) {
+        if (notesInLane.length >= 2) {
+          list.push({
+            label: `Remove duplicate note on ${lane}`,
+            action: () => {
+              const idsToRemove = notesInLane.slice(1).map((n) => n.id)
+              return draftNotes.filter((n) => !idsToRemove.includes(n.id))
+            }
+          })
+        }
+      }
+    }
+
+    return list
+  }, [issue.message, draftNotes, tick])
+
+  const uniqueSuggestions = useMemo(() => {
+    const seen = new Set<string>()
+    return suggestions.filter((sug) => {
+      if (seen.has(sug.label)) return false
+      seen.add(sug.label)
+      return true
+    })
+  }, [suggestions])
+
+  const handleApply = async (): Promise<void> => {
+    // 1. Delete all existing notes of this instrument & difficulty in the window [startTick, endTick]
+    const existingInWindow = songStore
+      .getState()
+      .song.notes.filter(
+        (n) =>
+          n.instrument === instrument &&
+          n.difficulty === difficulty &&
+          n.tick >= startTick &&
+          n.tick <= endTick
+      )
+
+    for (const note of existingInWindow) {
+      songStore.getState().deleteNote(note.id)
+    }
+
+    // 2. Add the sandbox notes back
+    for (const note of draftNotes) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { id: _id, ...noteData } = note
+      songStore.getState().addNote(noteData)
+    }
+
+    // 3. Re-run validation so the list updates live
+    try {
+      const updatedState = songStore.getState()
+      const settings = useSettingsStore.getState()
+      const newIssues = await validateChartAsync(updatedState.song, settings)
+      useUIStore.getState().setValidationIssues(newIssues)
+    } catch (err) {
+      console.error('[handleApply re-validation failed]', err)
+    }
+  }
+
+  const handleJumpToTick = (): void => {
+    songStore.getState().setCurrentTick(tick)
+  }
+
+  if (issue.tick === undefined || !issue.instrument || !issue.difficulty) {
+    return (
+      <div
+        style={{
+          padding: '12px 16px',
+          marginBottom: '8px',
+          borderRadius: '6px',
+          backgroundColor:
+            issue.severity === 'error' ? 'rgba(220,50,50,0.1)' : 'rgba(255,180,0,0.08)',
+          borderLeft: `4px solid ${issue.severity === 'error' ? '#dc3232' : '#ffb400'}`,
+          color: '#ddd',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '4px'
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <span
+            style={{
+              fontSize: '11px',
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              color: issue.severity === 'error' ? '#ff6b6b' : '#ffcc44'
+            }}
+          >
+            {issue.severity === 'error' ? '✖ Error' : '⚠ Warning'}
+          </span>
+        </div>
+        <div style={{ fontSize: '13px', lineHeight: 1.4 }}>{issue.message}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      style={{
+        padding: '16px',
+        marginBottom: '12px',
+        borderRadius: '8px',
+        backgroundColor: '#1b1b26',
+        border: '1px solid #2d2d3d',
+        borderLeft: `4px solid ${isDraftValid ? '#2ecc71' : issue.severity === 'error' ? '#ff4d4d' : '#ffa502'}`,
+        boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px',
+        transition: 'border-left 0.2s ease'
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <span
+            style={{
+              fontSize: '11px',
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              color: isDraftValid ? '#2ecc71' : issue.severity === 'error' ? '#ff6b6b' : '#ffa502',
+              padding: '2px 6px',
+              backgroundColor: isDraftValid
+                ? 'rgba(46,204,113,0.15)'
+                : issue.severity === 'error'
+                  ? 'rgba(255,107,107,0.15)'
+                  : 'rgba(255,165,2,0.15)',
+              borderRadius: '4px',
+              transition: 'all 0.2s'
+            }}
+          >
+            {isDraftValid ? 'Resolved' : issue.severity === 'error' ? '✖ Error' : '⚠ Warning'}
+          </span>
+          <span style={{ fontSize: '12px', color: '#888', fontWeight: 600 }}>
+            {instrument} • {difficulty} • Tick {tick}
+          </span>
+        </div>
+        <button
+          onClick={handleJumpToTick}
+          style={{
+            padding: '4px 8px',
+            fontSize: '11px',
+            fontWeight: 600,
+            background: 'rgba(255,255,255,0.06)',
+            color: '#fff',
+            border: '1px solid rgba(255,255,255,0.15)',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            transition: 'background 0.2s'
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = 'rgba(255,255,255,0.12)'
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.background = 'rgba(255,255,255,0.06)'
+          }}
+        >
+          Jump to Tick
+        </button>
+      </div>
+
+      <div style={{ fontSize: '13px', color: '#eee', lineHeight: 1.4, fontWeight: 500 }}>
+        {issue.message}
+      </div>
+
+      {/* SVG timeline preview full width */}
+      <div
+        style={{
+          backgroundColor: '#111118',
+          border: '1px solid #222230',
+          borderRadius: '6px',
+          width: '100%',
+          position: 'relative',
+          overflow: 'hidden'
+        }}
+      >
+        <svg viewBox="0 0 800 95" style={{ width: '100%', height: 'auto', display: 'block' }}>
+          {svgDefs}
+          {backgroundLines}
+          {verticalGridLines}
+          {handPaths}
+          {renderedNotes}
+          {gridCells}
+        </svg>
+      </div>
+
+      {/* Controls container below preview */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', width: '100%' }}>
+        {/* Quick Edit lane buttons */}
+        {lanes.length > 0 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+            <span
+              style={{
+                fontSize: '11px',
+                color: '#666',
+                fontWeight: 700,
+                textTransform: 'uppercase'
+              }}
+            >
+              Quick Edit:
+            </span>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+              {lanes.map((lane) => {
+                const isActive = draftNotes.some((n) => {
+                  if (n.tick !== tick) return false
+                  if (lane === 'doubleKick') {
+                    return String(n.lane) === 'kick' && !!n.flags?.isDoubleKick
+                  }
+                  if (lane === 'kick') {
+                    return String(n.lane) === 'kick' && !n.flags?.isDoubleKick
+                  }
+                  return String(n.lane) === lane
+                })
+
+                let btnLabel = lane
+                let btnColor = 'rgba(255,255,255,0.05)'
+                let activeColor = '#666'
+
+                if (instrument === 'drums') {
+                  if (lane === 'kick') {
+                    btnLabel = 'Kick'
+                    btnColor = 'rgba(255, 132, 0, 0.15)'
+                    activeColor = '#FF8400'
+                  } else if (lane === 'doubleKick') {
+                    btnLabel = '2Kick'
+                    btnColor = 'rgba(184, 81, 0, 0.15)'
+                    activeColor = '#B85100'
+                  } else if (lane === 'snare') {
+                    btnLabel = 'Snare'
+                    btnColor = 'rgba(255, 29, 35, 0.15)'
+                    activeColor = '#FF1D23'
+                  } else if (lane === 'yellowTom') {
+                    btnLabel = 'Y-Tom'
+                    btnColor = 'rgba(255, 233, 0, 0.15)'
+                    activeColor = '#FFE900'
+                  } else if (lane === 'yellowCymbal') {
+                    btnLabel = 'Y-Cym'
+                    btnColor = 'rgba(255, 233, 0, 0.15)'
+                    activeColor = '#FFE900'
+                  } else if (lane === 'blueTom') {
+                    btnLabel = 'B-Tom'
+                    btnColor = 'rgba(0, 191, 255, 0.15)'
+                    activeColor = '#00BFFF'
+                  } else if (lane === 'blueCymbal') {
+                    btnLabel = 'B-Cym'
+                    btnColor = 'rgba(0, 191, 255, 0.15)'
+                    activeColor = '#00BFFF'
+                  } else if (lane === 'greenTom') {
+                    btnLabel = 'G-Tom'
+                    btnColor = 'rgba(121, 211, 4, 0.15)'
+                    activeColor = '#79D304'
+                  } else if (lane === 'greenCymbal') {
+                    btnLabel = 'G-Cym'
+                    btnColor = 'rgba(121, 211, 4, 0.15)'
+                    activeColor = '#79D304'
+                  }
+                } else if (instrument === 'guitar' || instrument === 'bass') {
+                  if (lane === 'open') {
+                    btnLabel = 'Open'
+                    btnColor = 'rgba(200, 0, 255, 0.15)'
+                    activeColor = '#C800FF'
+                  } else if (lane === 'green') {
+                    btnLabel = 'Green'
+                    btnColor = 'rgba(121, 211, 4, 0.15)'
+                    activeColor = '#79D304'
+                  } else if (lane === 'red') {
+                    btnLabel = 'Red'
+                    btnColor = 'rgba(255, 29, 35, 0.15)'
+                    activeColor = '#FF1D23'
+                  } else if (lane === 'yellow') {
+                    btnLabel = 'Yellow'
+                    btnColor = 'rgba(255, 233, 0, 0.15)'
+                    activeColor = '#FFE900'
+                  } else if (lane === 'blue') {
+                    btnLabel = 'Blue'
+                    btnColor = 'rgba(0, 191, 255, 0.15)'
+                    activeColor = '#00BFFF'
+                  } else if (lane === 'orange') {
+                    btnLabel = 'Orange'
+                    btnColor = 'rgba(255, 132, 0, 0.15)'
+                    activeColor = '#FF8400'
+                  }
+                }
+
+                return (
+                  <button
+                    key={lane}
+                    onClick={() => handleToggleDraftNote(lane, tick)}
+                    style={{
+                      padding: '4px 8px',
+                      fontSize: '11px',
+                      fontFamily: 'monospace',
+                      fontWeight: 'bold',
+                      borderRadius: '4px',
+                      border: `1px solid ${isActive ? activeColor : 'rgba(255,255,255,0.1)'}`,
+                      background: isActive ? activeColor : btnColor,
+                      color: isActive ? '#000' : '#aaa',
+                      cursor: 'pointer',
+                      boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+                      transition: 'all 0.15s ease'
+                    }}
+                    onMouseEnter={(e) => {
+                      if (!isActive) {
+                        e.currentTarget.style.border = `1px solid ${activeColor}`
+                        e.currentTarget.style.color = '#fff'
+                      }
+                    }}
+                    onMouseLeave={(e) => {
+                      if (!isActive) {
+                        e.currentTarget.style.border = '1px solid rgba(255,255,255,0.1)'
+                        e.currentTarget.style.color = '#aaa'
+                      }
+                    }}
+                  >
+                    {btnLabel}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Quick Suggestions list */}
+        {uniqueSuggestions.length > 0 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+            <span
+              style={{
+                fontSize: '11px',
+                color: '#666',
+                fontWeight: 700,
+                textTransform: 'uppercase'
+              }}
+            >
+              Quick suggestions:
+            </span>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+              {uniqueSuggestions.map((sug, idx) => (
+                <button
+                  key={idx}
+                  onClick={() => setDraftNotes(sug.action())}
+                  style={{
+                    padding: '4px 8px',
+                    fontSize: '11px',
+                    borderRadius: '4px',
+                    border: '1px solid rgba(0, 204, 255, 0.25)',
+                    background: 'rgba(0, 204, 255, 0.05)',
+                    color: '#00ccff',
+                    cursor: 'pointer',
+                    transition: 'all 0.15s'
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.background = 'rgba(0, 204, 255, 0.12)'
+                    e.currentTarget.style.borderColor = 'rgba(0, 204, 255, 0.45)'
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.background = 'rgba(0, 204, 255, 0.05)'
+                    e.currentTarget.style.borderColor = 'rgba(0, 204, 255, 0.25)'
+                  }}
+                >
+                  {sug.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Sandbox Status & Action row */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            borderTop: '1px solid #2d2d3d',
+            paddingTop: '8px',
+            marginTop: '4px'
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+            <div
+              style={{
+                width: '8px',
+                height: '8px',
+                borderRadius: '50%',
+                backgroundColor: isDraftValid ? '#2ecc71' : '#ff9f43',
+                boxShadow: isDraftValid ? '0 0 6px #2ecc71' : '0 0 6px #ff9f43',
+                transition: 'all 0.2s'
+              }}
+            />
+            <span
+              style={{
+                fontSize: '12px',
+                fontWeight: 600,
+                color: isDraftValid ? '#2ecc71' : '#ff9f43',
+                transition: 'color 0.2s'
+              }}
+            >
+              {isDraftValid ? 'Resolved (passes validation)' : 'Unresolved draft'}
+            </span>
+          </div>
+          <div style={{ display: 'flex', gap: '8px' }}>
+            {hasActiveDraft && (
+              <button
+                onClick={handleRevert}
+                style={{
+                  padding: '6px 12px',
+                  fontSize: '12px',
+                  fontWeight: 600,
+                  background: 'rgba(255,255,255,0.05)',
+                  color: '#aaa',
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                  transition: 'all 0.15s ease'
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = 'rgba(255,255,255,0.1)'
+                  e.currentTarget.style.color = '#fff'
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = 'rgba(255,255,255,0.05)'
+                  e.currentTarget.style.color = '#aaa'
+                }}
+              >
+                Revert
+              </button>
+            )}
+            <button
+              disabled={!isDraftValid}
+              onClick={handleApply}
+              style={{
+                padding: '6px 12px',
+                fontSize: '12px',
+                fontWeight: 700,
+                background: isDraftValid ? '#2ecc71' : 'rgba(255,255,255,0.03)',
+                color: isDraftValid ? '#000' : '#666',
+                border: isDraftValid ? 'none' : '1px solid rgba(255,255,255,0.05)',
+                borderRadius: '4px',
+                cursor: isDraftValid ? 'pointer' : 'not-allowed',
+                boxShadow: isDraftValid ? '0 0 10px rgba(46,204,113,0.3)' : 'none',
+                transition: 'all 0.15s ease'
+              }}
+              onMouseEnter={(e) => {
+                if (isDraftValid) e.currentTarget.style.transform = 'scale(1.03)'
+              }}
+              onMouseLeave={(e) => {
+                if (isDraftValid) e.currentTarget.style.transform = 'scale(1)'
+              }}
+            >
+              Apply Fix
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/stores/projectStore.ts
+++ b/src/renderer/src/stores/projectStore.ts
@@ -1,7 +1,7 @@
 // Project-level store (global state)
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import type { ProjectState, AppSettings, UIState, NoteModifiers } from '../types'
+import type { ProjectState, AppSettings, UIState, NoteModifiers, ValidationIssue } from '../types'
 import { cloneDefaultHotkeys } from '../utils/hotkeys'
 
 interface ProjectStore extends ProjectState {
@@ -64,7 +64,16 @@ const defaultSettings: AppSettings = {
   sngLastExportDir: undefined,
   betaUpdates: false,
   invertPianoRollVerticalScroll: false,
-  hotkeys: cloneDefaultHotkeys()
+  hotkeys: cloneDefaultHotkeys(),
+  validationMinSustainGuitar: 48,
+  validationMinSustainBass: 48,
+  validationMinSustainKeys: 48,
+  validationMinSustainDrums: 0,
+  validationEnableOverlapsCheck: true,
+  validationEnableStarPowerCheck: true,
+  validationEnableDrumImpossibilityCheck: true,
+  validationDrumTimeThresholdMs: 40,
+  validationDrumCrossoverThresholdMs: 80
 }
 
 export const useSettingsStore = create<SettingsStore>()(
@@ -102,6 +111,7 @@ interface UIStore extends UIState {
   setExportModalOpen: (open: boolean) => void
   toggleVocalPitchPlayback: () => void
   toggleHighwayWaveform: () => void
+  setValidationIssues: (issues: ValidationIssue[] | null) => void
 }
 
 const defaultModifiers: NoteModifiers = {
@@ -129,6 +139,7 @@ export const useUIStore = create<UIStore>()((set) => ({
   isExportModalOpen: false,
   vocalPitchPlayback: false,
   showHighwayWaveform: false,
+  validationIssues: null,
 
   // Actions
   setLeftPanelWidth: (width) => set({ leftPanelWidth: width }),
@@ -165,5 +176,6 @@ export const useUIStore = create<UIStore>()((set) => ({
   setSettingsModalOpen: (open) => set({ isSettingsModalOpen: open }),
   setExportModalOpen: (open) => set({ isExportModalOpen: open }),
   toggleVocalPitchPlayback: () => set((state) => ({ vocalPitchPlayback: !state.vocalPitchPlayback })),
-  toggleHighwayWaveform: () => set((state) => ({ showHighwayWaveform: !state.showHighwayWaveform }))
+  toggleHighwayWaveform: () => set((state) => ({ showHighwayWaveform: !state.showHighwayWaveform })),
+  setValidationIssues: (issues) => set({ validationIssues: issues })
 }))

--- a/src/renderer/src/stores/songStore.ts
+++ b/src/renderer/src/stores/songStore.ts
@@ -2,6 +2,11 @@
 import { create, StateCreator } from 'zustand'
 import { temporal, TemporalState } from 'zundo'
 import { v4 as uuidv4 } from 'uuid'
+import {
+  gridTicksForDivision,
+  snapEntriesToGrid,
+  SNAP_TO_GRID_TOLERANCE_FRACTION
+} from '../utils/snapToGrid'
 import type {
   SongData,
   SongEditorState,
@@ -35,7 +40,7 @@ interface SongStoreState extends SongEditorState {
   deleteNote: (noteId: string) => void
   deleteSelectedNotes: () => void
   swapLanes: (instrument: Instrument, laneA: string, laneB: string, difficulty?: Difficulty | 'all') => void
-  snapNotesToGrid: (division?: number) => void
+  snapNotesToGrid: (division?: number, toleranceTicks?: number) => void
 
   // Selection actions
   selectNote: (noteId: string, addToSelection?: boolean) => void
@@ -274,48 +279,47 @@ const createSongStoreSlice: StateCreator<SongStoreState> = (set) => {
     // therefore tempo-independent: a note at tick T moves to the nearest multiple
     // of (480 / division) ticks. Sustained notes keep their end aligned to the
     // grid as well so durations stay clean.
-    snapNotesToGrid: (division) =>
+    //
+    // Two behaviours (issue #22) keep snapping non-destructive:
+    //   1. Tolerance — a note is only moved when it already lies within
+    //      `toleranceTicks` of a grid line, so correctly-placed finer-subdivision
+    //      notes (syncopation, fills) are left untouched instead of being dragged
+    //      onto a coarser beat. Defaults to a fraction of the grid spacing.
+    //   2. De-duplication — notes that collapse onto the same
+    //      instrument|difficulty|lane|tick (or vocal part|tick) are merged,
+    //      keeping the longest sustain, so snapping never silently stacks notes
+    //      on top of each other (which the validator flags and which makes notes
+    //      "disappear" in game).
+    snapNotesToGrid: (division, toleranceTicks) =>
       set((state) => {
         const div = division ?? state.snapDivision
         if (!div || div <= 0) return {}
-        const snapTicks = 480 / div
-        const snap = (t: number): number => Math.round(t / snapTicks) * snapTicks
+        const gridTicks = gridTicksForDivision(div)
+        const tolerance = toleranceTicks ?? gridTicks * SNAP_TO_GRID_TOLERANCE_FRACTION
 
         const selectedNotes = new Set(state.selectedNoteIds)
         const selectedVocals = new Set(state.selectedVocalNoteIds)
         const hasSelection = selectedNotes.size > 0 || selectedVocals.size > 0
 
-        const snapEntry = <T extends { tick: number; duration: number }>(n: T): T => {
-          const newTick = snap(n.tick)
-          let newDuration = n.duration
-          if (n.duration > 0) {
-            newDuration = Math.max(0, snap(n.tick + n.duration) - newTick)
-          }
-          if (newTick === n.tick && newDuration === n.duration) return n
-          return { ...n, tick: newTick, duration: newDuration }
-        }
-
-        let changed = false
-
-        const notes = state.song.notes.map((n) => {
-          if (hasSelection && !selectedNotes.has(n.id)) return n
-          const snapped = snapEntry(n)
-          if (snapped !== n) changed = true
-          return snapped
+        const noteResult = snapEntriesToGrid(state.song.notes, {
+          gridTicks,
+          toleranceTicks: tolerance,
+          isEligible: (n) => !hasSelection || selectedNotes.has(n.id),
+          keyOf: (n) => `${n.instrument}|${n.difficulty}|${n.lane}|${n.tick}`
         })
 
-        const vocalNotes = state.song.vocalNotes.map((n) => {
-          if (hasSelection && !selectedVocals.has(n.id)) return n
-          const snapped = snapEntry(n)
-          if (snapped !== n) changed = true
-          return snapped
+        const vocalResult = snapEntriesToGrid(state.song.vocalNotes, {
+          gridTicks,
+          toleranceTicks: tolerance,
+          isEligible: (n) => !hasSelection || selectedVocals.has(n.id),
+          keyOf: (n) => `${n.harmonyPart}|${n.tick}`
         })
 
-        if (!changed) return {}
+        if (!noteResult.changed && !vocalResult.changed) return {}
 
         // Preserve the tick-sorted invariant after snapping.
-        notes.sort((a, b) => a.tick - b.tick)
-        vocalNotes.sort((a, b) => a.tick - b.tick)
+        const notes = [...noteResult.entries].sort((a, b) => a.tick - b.tick)
+        const vocalNotes = [...vocalResult.entries].sort((a, b) => a.tick - b.tick)
 
         return {
           song: { ...state.song, notes, vocalNotes },

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -252,6 +252,14 @@ export interface ProjectState {
   activeSongId: string | null
 }
 
+export interface ValidationIssue {
+  severity: 'error' | 'warning'
+  message: string
+  tick?: number
+  instrument?: Instrument
+  difficulty?: Difficulty
+}
+
 // Application settings
 export interface AppSettings {
   autosaveEnabled: boolean
@@ -271,6 +279,15 @@ export interface AppSettings {
   betaUpdates: boolean // Opt into beta/pre-release auto-updates
   invertPianoRollVerticalScroll: boolean // Reverse vertical wheel direction in the piano roll
   hotkeys: AppHotkeys
+  validationMinSustainGuitar: number
+  validationMinSustainBass: number
+  validationMinSustainKeys: number
+  validationMinSustainDrums: number
+  validationEnableOverlapsCheck: boolean
+  validationEnableStarPowerCheck: boolean
+  validationEnableDrumImpossibilityCheck: boolean
+  validationDrumTimeThresholdMs: number
+  validationDrumCrossoverThresholdMs: number
 }
 
 export type HotkeyAction =
@@ -335,6 +352,7 @@ export interface UIState {
   vocalPitchPlayback: boolean
   /** Show the audio waveform overlay on the 3D note highway (issue #7). */
   showHighwayWaveform: boolean
+  validationIssues: ValidationIssue[] | null
 }
 
 export interface SelectedVenueEventRef {

--- a/src/renderer/src/utils/chartValidation.test.ts
+++ b/src/renderer/src/utils/chartValidation.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest'
+import { validateChart, validateChartAsync } from './chartValidation'
+import type { Note, SongData } from '../types'
+
+describe('chartValidation', () => {
+  const mkNote = (over: Partial<Note>): Note => ({
+    id: `note-${Math.random().toString(36).substring(2, 9)}`,
+    tick: 0,
+    duration: 0,
+    instrument: 'drums',
+    difficulty: 'expert',
+    lane: 'snare',
+    velocity: 100,
+    ...over
+  })
+
+  const mkGuitarNote = (over: Partial<Note>): Note => ({
+    id: `note-${Math.random().toString(36).substring(2, 9)}`,
+    tick: 0,
+    duration: 120,
+    instrument: 'guitar',
+    difficulty: 'expert',
+    lane: 'green',
+    velocity: 100,
+    ...over
+  })
+
+  const mockSong = (notes: Note[]): SongData =>
+    ({
+      notes,
+      starPowerPhrases: [],
+      vocalNotes: [],
+      tempoEvents: [{ tick: 0, bpm: 120 }] // 120 BPM means 1 beat = 500ms, so 1 tick = 500/480 = 1.0416ms
+    }) as unknown as SongData
+
+  it('detects overlapping notes', () => {
+    const song = mockSong([
+      mkGuitarNote({ tick: 120, lane: 'green' }),
+      mkGuitarNote({ tick: 120, lane: 'green' })
+    ])
+    const issues = validateChart(song, {
+      validationEnableOverlapsCheck: true,
+      validationEnableStarPowerCheck: false
+    })
+    expect(issues.some((i) => i.message.includes('Overlapping note'))).toBe(true)
+  })
+
+  it('detects short sustains on guitar', () => {
+    const song = mockSong([
+      mkGuitarNote({ tick: 120, duration: 10 }) // min threshold is 48
+    ])
+    const issues = validateChart(song, {
+      validationMinSustainGuitar: 48,
+      validationEnableStarPowerCheck: false
+    })
+    expect(issues.some((i) => i.message.includes('Very short sustain'))).toBe(true)
+  })
+
+  it('detects three or more simultaneous hand hits on drums', () => {
+    const song = mockSong([
+      mkNote({ tick: 120, lane: 'snare' }),
+      mkNote({ tick: 120, lane: 'yellowTom' }),
+      mkNote({ tick: 120, lane: 'blueTom' })
+    ])
+    const issues = validateChart(song, {
+      validationEnableDrumImpossibilityCheck: true,
+      validationEnableStarPowerCheck: false
+    })
+    expect(issues.some((i) => i.message.includes('Three or more simultaneous hand hits'))).toBe(
+      true
+    )
+  })
+
+  it('detects physically impossible transition on same hand', () => {
+    // 120 BPM tempo: 1 tick = 1.0416ms
+    // Snare (LH) and Yellow Tom (RH) at t=0
+    // Snare (LH) and Blue Tom (LH) transition at t=20 (20 ticks = 20.8ms)
+    // Snare to Blue Tom (distance 2, limit 40ms, cymbal = false)
+    const song = mockSong([
+      // Chord 1 at tick 120
+      mkNote({ tick: 120, lane: 'snare' }), // LH
+      mkNote({ tick: 120, lane: 'yellowTom' }), // RH
+      // Chord 2 at tick 140 (20 ticks later = 20.8ms)
+      mkNote({ tick: 140, lane: 'blueTom' }), // LH or RH transition
+      mkNote({ tick: 140, lane: 'greenTom' })
+    ])
+    const issues = validateChart(song, {
+      validationEnableDrumImpossibilityCheck: true,
+      validationDrumTimeThresholdMs: 40,
+      validationDrumCrossoverThresholdMs: 80,
+      validationEnableStarPowerCheck: false
+    })
+
+    expect(
+      issues.some((i) => i.message.includes('Physically impossible transition between pads'))
+    ).toBe(true)
+  })
+
+  it('does NOT flag alternating fast rolls as violations', () => {
+    // Alternating Snare -> Yellow -> Blue -> Green roll at 30 ticks intervals (31.25ms)
+    // This alternating pattern is played as: LH -> RH -> LH -> RH
+    // Consecutive hits on LH: Snare (120) to Blue (180), dt = 60 ticks = 62.5ms (limit 40ms) -> possible!
+    // Consecutive hits on RH: Yellow (150) to Green (210), dt = 60 ticks = 62.5ms (limit 40ms) -> possible!
+    const song = mockSong([
+      mkNote({ tick: 120, lane: 'snare' }),
+      mkNote({ tick: 150, lane: 'yellowTom' }),
+      mkNote({ tick: 180, lane: 'blueTom' }),
+      mkNote({ tick: 210, lane: 'greenTom' })
+    ])
+    const issues = validateChart(song, {
+      validationEnableDrumImpossibilityCheck: true,
+      validationDrumTimeThresholdMs: 40,
+      validationDrumCrossoverThresholdMs: 80,
+      validationEnableStarPowerCheck: false
+    })
+    expect(issues.filter((i) => i.severity === 'error' || i.severity === 'warning').length).toBe(0)
+  })
+
+  it('does NOT flag simultaneous cymbal hits as crossovers', () => {
+    // Simultaneous Yellow Cymbal and Green Cymbal played repeatedly at 50ms intervals
+    // LH stays on Yellow Cymbal, RH stays on Green Cymbal. No transitions.
+    const song = mockSong([
+      mkNote({ tick: 120, lane: 'yellowCymbal' }), // LH
+      mkNote({ tick: 120, lane: 'greenCymbal' }), // RH
+
+      mkNote({ tick: 170, lane: 'yellowCymbal' }), // LH
+      mkNote({ tick: 170, lane: 'greenCymbal' }), // RH
+
+      mkNote({ tick: 220, lane: 'yellowCymbal' }), // LH
+      mkNote({ tick: 220, lane: 'greenCymbal' }) // RH
+    ])
+    const issues = validateChart(song, {
+      validationEnableDrumImpossibilityCheck: true,
+      validationDrumTimeThresholdMs: 40,
+      validationDrumCrossoverThresholdMs: 80,
+      validationEnableStarPowerCheck: false
+    })
+    expect(issues.filter((i) => i.severity === 'error' || i.severity === 'warning').length).toBe(0)
+  })
+
+  it('handles validation engine errors gracefully', () => {
+    const issues = validateChart(null as unknown as SongData)
+    expect(
+      issues.some((i) => i.severity === 'error' && i.message.includes('No song data provided.'))
+    ).toBe(true)
+  })
+
+  it('validateChartAsync falls back to sync or runs worker successfully', async () => {
+    const song = mockSong([
+      mkGuitarNote({ tick: 120, lane: 'green' }),
+      mkGuitarNote({ tick: 120, lane: 'green' })
+    ])
+    const issues = await validateChartAsync(song, {
+      validationEnableOverlapsCheck: true,
+      validationEnableStarPowerCheck: false
+    })
+    expect(issues.some((i) => i.message.includes('Overlapping note'))).toBe(true)
+  })
+})

--- a/src/renderer/src/utils/chartValidation.ts
+++ b/src/renderer/src/utils/chartValidation.ts
@@ -1,103 +1,498 @@
-import type { SongData, Note, Instrument, Difficulty } from '../types'
+import type { SongData, Note, Instrument, Difficulty, AppSettings, ValidationIssue } from '../types'
 
-export interface ValidationIssue {
-  severity: 'error' | 'warning'
-  message: string
-  tick?: number
-  instrument?: Instrument
-  difficulty?: Difficulty
+export function tickToMs(tick: number, tempoEvents: { tick: number; bpm: number }[]): number {
+  if (tempoEvents.length === 0) {
+    return (tick / ((480 * 120) / 60)) * 1000
+  }
+
+  let totalSeconds = 0
+  let currentTick = 0
+  let currentBpm = tempoEvents[0].bpm
+
+  for (let i = 0; i < tempoEvents.length; i++) {
+    const event = tempoEvents[i]
+    if (tick <= event.tick) {
+      break
+    }
+    const deltaTicks = event.tick - currentTick
+    totalSeconds += deltaTicks / ((480 * currentBpm) / 60)
+
+    currentTick = event.tick
+    currentBpm = event.bpm
+  }
+
+  if (tick > currentTick) {
+    const deltaTicks = tick - currentTick
+    totalSeconds += deltaTicks / ((480 * currentBpm) / 60)
+  }
+
+  return totalSeconds * 1000
 }
 
-// Major sustain threshold in ticks (480 PPQ = 1 beat at 120BPM)
-const MIN_SUSTAIN_TICKS = 48 // ~1/10 beat — shorter is probably a data glitch
+export const isHandHit = (note: Note): boolean => {
+  const laneStr = String(note.lane)
+  return laneStr !== 'kick' && laneStr !== 'doubleKick' && !note.flags?.isDoubleKick
+}
 
-export function validateChart(song: SongData): ValidationIssue[] {
+export const isCymbal = (note: Note): boolean => {
+  const laneStr = String(note.lane)
+  return laneStr.includes('Cymbal') || note.flags?.isCymbal === true
+}
+
+export const getDrumLaneIndex = (note: Note): number => {
+  const laneStr = String(note.lane)
+  if (laneStr === 'snare') return 0
+  if (laneStr.startsWith('yellow')) return 1
+  if (laneStr.startsWith('blue')) return 2
+  if (laneStr.startsWith('green')) return 3
+  return -1
+}
+
+export function getDrumTransitionLimit(
+  n1: Note,
+  n2: Note,
+  settings: {
+    validationDrumTimeThresholdMs: number
+    validationDrumCrossoverThresholdMs: number
+  }
+): { limit: number; isCrossover: boolean } {
+  const l1 = getDrumLaneIndex(n1)
+  const l2 = getDrumLaneIndex(n2)
+  if (l1 === -1 || l2 === -1 || l1 === l2) return { limit: 0, isCrossover: false }
+
+  const distance = Math.abs(l1 - l2)
+  const hasCymbal = isCymbal(n1) || isCymbal(n2)
+  const isCrossover = distance === 3
+
+  let limit = 0
+  if (isCrossover) {
+    limit = hasCymbal
+      ? settings.validationDrumCrossoverThresholdMs * 1.5
+      : settings.validationDrumCrossoverThresholdMs
+  } else {
+    limit = hasCymbal
+      ? settings.validationDrumTimeThresholdMs * 1.25
+      : settings.validationDrumTimeThresholdMs
+  }
+  return { limit, isCrossover }
+}
+
+export function getDrumHandAssignments(
+  notes: Note[],
+  tempoEvents: { tick: number; bpm: number }[]
+): Map<string, 'LH' | 'RH'> {
+  const assignments = new Map<string, 'LH' | 'RH'>()
+  if (notes.length === 0) return assignments
+
+  // Group notes by tick
+  const ticksMap = new Map<number, Note[]>()
+  for (const n of notes) {
+    let list = ticksMap.get(n.tick)
+    if (!list) {
+      list = []
+      ticksMap.set(n.tick, list)
+    }
+    list.push(n)
+  }
+
+  const sortedTicks = Array.from(ticksMap.keys()).sort((a, b) => a - b)
+
+  let lastLHNote: Note | null = null
+  let lastRHNote: Note | null = null
+
+  for (const t of sortedTicks) {
+    const notesAtTick = ticksMap.get(t) || []
+
+    // If there are 2 or more notes at this tick (chord)
+    if (notesAtTick.length >= 2) {
+      // Sort from leftmost lane (index 0) to rightmost lane (index 3)
+      const sorted = [...notesAtTick].sort((a, b) => getDrumLaneIndex(a) - getDrumLaneIndex(b))
+
+      // Leftmost note is LH
+      assignments.set(sorted[0].id, 'LH')
+      // Rightmost note is RH
+      assignments.set(sorted[sorted.length - 1].id, 'RH')
+
+      // Any middle notes
+      for (let i = 1; i < sorted.length - 1; i++) {
+        const mid = sorted[i]
+        const idx = getDrumLaneIndex(mid)
+        // Assign to closest hand
+        const lastLHLane = lastLHNote ? getDrumLaneIndex(lastLHNote) : -1
+        const lastRHLane = lastRHNote ? getDrumLaneIndex(lastRHNote) : -1
+        const distLH = lastLHLane !== -1 ? Math.abs(idx - lastLHLane) : idx
+        const distRH = lastRHLane !== -1 ? Math.abs(idx - lastRHLane) : 3 - idx
+        if (distLH <= distRH) {
+          assignments.set(mid.id, 'LH')
+        } else {
+          assignments.set(mid.id, 'RH')
+        }
+      }
+
+      lastLHNote = sorted[0]
+      lastRHNote = sorted[sorted.length - 1]
+    }
+    // If there is only 1 note at this tick (single hit)
+    else if (notesAtTick.length === 1) {
+      const n = notesAtTick[0]
+      const idx = getDrumLaneIndex(n) // 0=snare, 1=yellow, 2=blue, 3=green
+
+      let chosenHand: 'LH' | 'RH' = 'LH'
+
+      // Helper to check if a transition for a hand is "possible"
+      const canLHPlay = (): boolean => {
+        if (!lastLHNote) return true
+        const dt = tickToMs(t, tempoEvents) - tickToMs(lastLHNote.tick, tempoEvents)
+        const lastIdx = getDrumLaneIndex(lastLHNote)
+        const dist = Math.abs(idx - lastIdx)
+        if (dist === 0) return true
+        const isCym = isCymbal(n) || isCymbal(lastLHNote)
+        if (dist === 3) {
+          const limit = isCym ? 120 : 80
+          return dt >= limit - 1
+        } else {
+          const limit = isCym ? 50 : 40
+          return dt >= limit - 1
+        }
+      }
+
+      const canRHPlay = (): boolean => {
+        if (!lastRHNote) return true
+        const dt = tickToMs(t, tempoEvents) - tickToMs(lastRHNote.tick, tempoEvents)
+        const lastIdx = getDrumLaneIndex(lastRHNote)
+        const dist = Math.abs(idx - lastIdx)
+        if (dist === 0) return true
+        const isCym = isCymbal(n) || isCymbal(lastRHNote)
+        if (dist === 3) {
+          const limit = isCym ? 120 : 80
+          return dt >= limit - 1
+        } else {
+          const limit = isCym ? 50 : 40
+          return dt >= limit - 1
+        }
+      }
+
+      const lhFeasible = canLHPlay()
+      const rhFeasible = canRHPlay()
+
+      // If only one hand is physically feasible, we MUST use it!
+      if (lhFeasible && !rhFeasible) {
+        chosenHand = 'LH'
+      } else if (!lhFeasible && rhFeasible) {
+        chosenHand = 'RH'
+      } else {
+        // If both or neither are feasible, we decide based on natural lanes and alternation:
+        if (idx === 0) {
+          chosenHand = 'LH'
+        } else if (idx === 3) {
+          chosenHand = 'RH'
+        } else {
+          const timeSinceLastLH = lastLHNote
+            ? tickToMs(t, tempoEvents) - tickToMs(lastLHNote.tick, tempoEvents)
+            : Infinity
+          const timeSinceLastRH = lastRHNote
+            ? tickToMs(t, tempoEvents) - tickToMs(lastRHNote.tick, tempoEvents)
+            : Infinity
+
+          const lastActiveHand = (lastLHNote?.tick ?? -1) > (lastRHNote?.tick ?? -1) ? 'LH' : 'RH'
+          const minTime = Math.min(timeSinceLastLH, timeSinceLastRH)
+
+          if (minTime < 250) {
+            chosenHand = lastActiveHand === 'LH' ? 'RH' : 'LH'
+          } else {
+            chosenHand = idx === 1 ? 'LH' : 'RH'
+          }
+        }
+      }
+
+      assignments.set(n.id, chosenHand)
+      if (chosenHand === 'LH') {
+        lastLHNote = n
+      } else {
+        lastRHNote = n
+      }
+    }
+  }
+
+  return assignments
+}
+
+export function validateChart(song: SongData, settings?: Partial<AppSettings>): ValidationIssue[] {
   const issues: ValidationIssue[] = []
-  const { notes, starPowerPhrases, vocalNotes, tempoEvents } = song
 
-  if (notes.length === 0 && vocalNotes.length === 0) {
-    issues.push({ severity: 'warning', message: 'Chart has no notes on any instrument.' })
-    return issues
-  }
-
-  // --- 1. Overlapping notes (same instrument + difficulty + lane at same tick) ---
-  const noteMap = new Map<string, Note>()
-  for (const note of notes) {
-    const key = `${note.instrument}|${note.difficulty}|${note.lane}|${note.tick}`
-    if (noteMap.has(key)) {
-      issues.push({
-        severity: 'error',
-        message: `Overlapping note at tick ${note.tick} (${note.instrument} ${note.difficulty} lane ${note.lane})`,
-        tick: note.tick,
-        instrument: note.instrument,
-        difficulty: note.difficulty
-      })
-    } else {
-      noteMap.set(key, note)
+  try {
+    if (!song) {
+      issues.push({ severity: 'error', message: 'No song data provided.' })
+      return issues
     }
-  }
 
-  // --- 2. Very short sustains (likely authoring mistake) ---
-  for (const note of notes) {
-    if (note.duration > 0 && note.duration < MIN_SUSTAIN_TICKS) {
+    const notes = song.notes || []
+    const starPowerPhrases = song.starPowerPhrases || []
+    const vocalNotes = song.vocalNotes || []
+    const tempoEvents = song.tempoEvents || []
+
+    if (notes.length === 0 && vocalNotes.length === 0) {
+      issues.push({ severity: 'warning', message: 'Chart has no notes on any instrument.' })
+      return issues
+    }
+
+    // Load configuration defaults if settings are not passed
+    const config = {
+      validationMinSustainGuitar: settings?.validationMinSustainGuitar ?? 48,
+      validationMinSustainBass: settings?.validationMinSustainBass ?? 48,
+      validationMinSustainKeys: settings?.validationMinSustainKeys ?? 48,
+      validationMinSustainDrums: settings?.validationMinSustainDrums ?? 0,
+      validationEnableOverlapsCheck: settings?.validationEnableOverlapsCheck ?? true,
+      validationEnableStarPowerCheck: settings?.validationEnableStarPowerCheck ?? true,
+      validationEnableDrumImpossibilityCheck:
+        settings?.validationEnableDrumImpossibilityCheck ?? true,
+      validationDrumTimeThresholdMs: settings?.validationDrumTimeThresholdMs ?? 40,
+      validationDrumCrossoverThresholdMs: settings?.validationDrumCrossoverThresholdMs ?? 80
+    }
+
+    // --- 1. Overlapping notes (same instrument + difficulty + lane at same tick) ---
+    if (config.validationEnableOverlapsCheck) {
+      const noteMap = new Map<string, Note>()
+      for (const note of notes) {
+        const key = `${note.instrument}|${note.difficulty}|${note.lane}|${note.tick}`
+        if (noteMap.has(key)) {
+          issues.push({
+            severity: 'error',
+            message: `Overlapping note at tick ${note.tick} (${note.instrument} ${note.difficulty} lane ${note.lane})`,
+            tick: note.tick,
+            instrument: note.instrument,
+            difficulty: note.difficulty
+          })
+        } else {
+          noteMap.set(key, note)
+        }
+      }
+    }
+
+    // --- 2. Very short sustains (likely authoring mistake) ---
+    for (const note of notes) {
+      if (note.duration > 0) {
+        let minSustain = 0
+        if (note.instrument === 'guitar') minSustain = config.validationMinSustainGuitar
+        else if (note.instrument === 'bass') minSustain = config.validationMinSustainBass
+        else if (note.instrument === 'keys' || note.instrument === 'proKeys')
+          minSustain = config.validationMinSustainKeys
+        else if (note.instrument === 'drums') minSustain = config.validationMinSustainDrums
+
+        if (minSustain > 0 && note.duration < minSustain) {
+          issues.push({
+            severity: 'warning',
+            message: `Very short sustain (${note.duration} ticks) at tick ${note.tick} on ${note.instrument} ${note.difficulty} (min threshold: ${minSustain})`,
+            tick: note.tick,
+            instrument: note.instrument,
+            difficulty: note.difficulty
+          })
+        }
+      }
+    }
+
+    // --- 3. Instruments with notes but no star power ---
+    if (config.validationEnableStarPowerCheck) {
+      const instrumentsWithNotes = new Set<string>()
+      for (const note of notes) {
+        instrumentsWithNotes.add(`${note.instrument}|${note.difficulty}`)
+      }
+      const instrumentsWithSP = new Set<string>()
+      for (const sp of starPowerPhrases) {
+        for (const diff of ['expert', 'hard', 'medium', 'easy'] as Difficulty[]) {
+          instrumentsWithSP.add(`${sp.instrument}|${diff}`)
+        }
+      }
+      for (const key of instrumentsWithNotes) {
+        if (!instrumentsWithSP.has(key)) {
+          const [inst, diff] = key.split('|')
+          issues.push({
+            severity: 'warning',
+            message: `No star power phrases for ${inst} (${diff})`,
+            instrument: inst as Instrument,
+            difficulty: diff as Difficulty
+          })
+        }
+      }
+    }
+
+    // --- 4. Notes beyond end of tempo map last event ---
+    const lastTempoTick = tempoEvents.length > 0 ? tempoEvents[tempoEvents.length - 1].tick : 0
+    if (notes.length > 0) {
+      const lastNoteTick = Math.max(...notes.map((n) => n.tick))
+      if (lastTempoTick > 0 && lastNoteTick > lastTempoTick * 4) {
+        issues.push({
+          severity: 'warning',
+          message: `Notes extend far beyond last tempo event (last note: tick ${lastNoteTick}, last tempo: tick ${lastTempoTick}). Check tempo map.`
+        })
+      }
+    }
+
+    // --- 5. Vocal notes with no lyrics (except percussion) ---
+    const vocalNotesWithoutLyric = vocalNotes.filter((n) => !n.isPercussion && !n.lyric)
+    if (vocalNotesWithoutLyric.length > 5) {
       issues.push({
         severity: 'warning',
-        message: `Very short sustain (${note.duration} ticks) at tick ${note.tick} on ${note.instrument} ${note.difficulty}`,
-        tick: note.tick,
-        instrument: note.instrument,
-        difficulty: note.difficulty
+        message: `${vocalNotesWithoutLyric.length} vocal notes have no lyric text.`,
+        instrument: 'vocals'
       })
     }
-  }
 
-  // --- 3. Instruments with notes but no star power ---
-  const instrumentsWithNotes = new Set<string>()
-  for (const note of notes) {
-    instrumentsWithNotes.add(`${note.instrument}|${note.difficulty}`)
-  }
-  const instrumentsWithSP = new Set<string>()
-  for (const sp of starPowerPhrases) {
-    // SP applies across difficulties for the instrument
-    for (const diff of ['expert', 'hard', 'medium', 'easy'] as Difficulty[]) {
-      instrumentsWithSP.add(`${sp.instrument}|${diff}`)
+    // --- 6. Drum physical check ---
+    if (config.validationEnableDrumImpossibilityCheck) {
+      const drumNotes = notes.filter((n) => n.instrument === 'drums')
+      const difficulties: Difficulty[] = ['expert', 'hard', 'medium', 'easy']
+
+      for (const diff of difficulties) {
+        const diffDrumNotes = drumNotes.filter((n) => n.difficulty === diff)
+        if (diffDrumNotes.length === 0) continue
+
+        // Chords (3+ hands) check
+        const hitsByTick = new Map<number, Note[]>()
+        for (const note of diffDrumNotes) {
+          if (!isHandHit(note)) continue
+          let arr = hitsByTick.get(note.tick)
+          if (!arr) {
+            arr = []
+            hitsByTick.set(note.tick, arr)
+          }
+          arr.push(note)
+        }
+
+        for (const [tick, hits] of hitsByTick.entries()) {
+          if (hits.length >= 3) {
+            issues.push({
+              severity: 'error',
+              message: `Three or more simultaneous hand hits (${hits.length}) is physically impossible on drums at tick ${tick} (${diff})`,
+              tick,
+              instrument: 'drums',
+              difficulty: diff
+            })
+          }
+        }
+
+        // Hand path speed limits and crossover checks
+        const handNotesOnly = diffDrumNotes.filter(isHandHit).sort((a, b) => a.tick - b.tick)
+        const assignments = getDrumHandAssignments(handNotesOnly, tempoEvents)
+
+        const lhNotes = handNotesOnly.filter((n) => assignments.get(n.id) === 'LH')
+        const rhNotes = handNotesOnly.filter((n) => assignments.get(n.id) === 'RH')
+
+        const checkHandPath = (handNotes: Note[]): void => {
+          for (let i = 1; i < handNotes.length; i++) {
+            const n1 = handNotes[i - 1]
+            const n2 = handNotes[i]
+
+            const dt = tickToMs(n2.tick, tempoEvents) - tickToMs(n1.tick, tempoEvents)
+            if (dt >= 200) continue
+
+            const l1 = getDrumLaneIndex(n1)
+            const l2 = getDrumLaneIndex(n2)
+            if (l1 === -1 || l2 === -1 || l1 === l2) continue
+
+            const distance = Math.abs(l1 - l2)
+            const hasCymbal = isCymbal(n1) || isCymbal(n2)
+
+            if (distance === 3) {
+              // Crossover check (Snare to Green or Green to Snare)
+              // Cymbals have increased crossover limit (1.5x)
+              const threshold = hasCymbal
+                ? config.validationDrumCrossoverThresholdMs * 1.5
+                : config.validationDrumCrossoverThresholdMs
+
+              // Apply 1ms tolerance to avoid floating-point rounding issues on exact limits
+              if (dt < threshold - 1) {
+                issues.push({
+                  severity: 'warning',
+                  message: `Impossible crossover transition (${n1.lane} to ${n2.lane}, dt: ${Math.round(dt)}ms, limit: ${Math.round(threshold)}ms) at tick ${n2.tick} (${diff})`,
+                  tick: n2.tick,
+                  instrument: 'drums',
+                  difficulty: diff
+                })
+              }
+            } else {
+              // Standard transition (distance 1 or 2)
+              // Cymbals have increased transition limit (1.25x)
+              const threshold = hasCymbal
+                ? config.validationDrumTimeThresholdMs * 1.25
+                : config.validationDrumTimeThresholdMs
+
+              // Apply 1ms tolerance to avoid floating-point rounding issues on exact limits
+              if (dt < threshold - 1) {
+                issues.push({
+                  severity: 'error',
+                  message: `Physically impossible transition between pads (${n1.lane} to ${n2.lane}, dt: ${Math.round(dt)}ms, limit: ${Math.round(threshold)}ms) at tick ${n2.tick} (${diff})`,
+                  tick: n2.tick,
+                  instrument: 'drums',
+                  difficulty: diff
+                })
+              }
+            }
+          }
+        }
+
+        checkHandPath(lhNotes)
+        checkHandPath(rhNotes)
+      }
     }
-  }
-  for (const key of instrumentsWithNotes) {
-    if (!instrumentsWithSP.has(key)) {
-      const [inst, diff] = key.split('|')
-      issues.push({
-        severity: 'warning',
-        message: `No star power phrases for ${inst} (${diff})`,
-        instrument: inst as Instrument,
-        difficulty: diff as Difficulty
-      })
-    }
-  }
-
-  // --- 4. Notes beyond end of tempo map last event (possible missing tempo) ---
-  const lastTempoTick = tempoEvents.length > 0 ? tempoEvents[tempoEvents.length - 1].tick : 0
-  if (notes.length > 0) {
-    const lastNoteTick = notes[notes.length - 1].tick
-    if (lastTempoTick > 0 && lastNoteTick > lastTempoTick * 4) {
-      issues.push({
-        severity: 'warning',
-        message: `Notes extend far beyond last tempo event (last note: tick ${lastNoteTick}, last tempo: tick ${lastTempoTick}). Check tempo map.`
-      })
-    }
-  }
-
-  // --- 5. Notes during the same tick on the same instrument/difficulty (chord check for single-note instruments) ---
-  // Guitar/bass should generally only have one note per lane per tick — but chords are valid, so skip.
-
-  // --- 6. Vocal notes with no lyrics (except percussion) ---
-  const vocalNotesWithoutLyric = vocalNotes.filter(n => !n.isPercussion && !n.lyric)
-  if (vocalNotesWithoutLyric.length > 5) {
+  } catch (error) {
+    console.error('[Chart Validation Error]', error)
+    const errMsg = error instanceof Error ? error.message : String(error)
     issues.push({
-      severity: 'warning',
-      message: `${vocalNotesWithoutLyric.length} vocal notes have no lyric text.`,
-      instrument: 'vocals'
+      severity: 'error',
+      message: `Validation engine error: ${errMsg}`
     })
   }
 
   return issues
+}
+
+let activeWorker: Worker | null = null
+
+export function validateChartAsync(
+  song: SongData,
+  settings?: Partial<AppSettings>
+): Promise<ValidationIssue[]> {
+  return new Promise((resolve, reject) => {
+    try {
+      if (!activeWorker) {
+        activeWorker = new Worker(new URL('./chartValidation.worker.ts', import.meta.url), {
+          type: 'module'
+        })
+      }
+
+      const handler = (event: MessageEvent): void => {
+        activeWorker?.removeEventListener('message', handler)
+        activeWorker?.removeEventListener('error', errorHandler)
+        if (event.data.type === 'success') {
+          resolve(event.data.issues)
+        } else {
+          reject(new Error(event.data.error))
+        }
+      }
+
+      const errorHandler = (err: ErrorEvent): void => {
+        activeWorker?.removeEventListener('message', handler)
+        activeWorker?.removeEventListener('error', errorHandler)
+        activeWorker?.terminate()
+        activeWorker = null
+        reject(err.error || new Error('Worker execution error'))
+      }
+
+      activeWorker.addEventListener('message', handler)
+      activeWorker.addEventListener('error', errorHandler)
+      activeWorker.postMessage({ song, settings })
+    } catch (workerErr) {
+      console.warn(
+        'Failed to start web worker for validation, falling back to sync validation:',
+        workerErr
+      )
+      try {
+        const issues = validateChart(song, settings)
+        resolve(issues)
+      } catch (err) {
+        reject(err)
+      }
+    }
+  })
 }

--- a/src/renderer/src/utils/chartValidation.worker.ts
+++ b/src/renderer/src/utils/chartValidation.worker.ts
@@ -1,0 +1,12 @@
+import { validateChart } from './chartValidation'
+
+self.onmessage = (event) => {
+  const { song, settings } = event.data
+  try {
+    const issues = validateChart(song, settings)
+    self.postMessage({ type: 'success', issues })
+  } catch (error) {
+    const errMsg = error instanceof Error ? error.message : String(error)
+    self.postMessage({ type: 'error', error: errMsg })
+  }
+}

--- a/src/renderer/src/utils/snapToGrid.test.ts
+++ b/src/renderer/src/utils/snapToGrid.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import {
+  snapTickToGrid,
+  gridTicksForDivision,
+  snapEntriesToGrid,
+  SNAP_TO_GRID_TOLERANCE_FRACTION
+} from './snapToGrid'
+
+interface TestNote {
+  id: string
+  tick: number
+  duration: number
+  lane: string
+}
+
+let idCounter = 0
+const mkNote = (over: Partial<TestNote>): TestNote => ({
+  id: `n${idCounter++}`,
+  tick: 0,
+  duration: 0,
+  lane: 'snare',
+  ...over
+})
+
+const snapAll = <T extends { tick: number; duration: number }>(
+  entries: T[],
+  gridTicks: number,
+  keyOf: (e: T) => string,
+  toleranceTicks = Infinity
+): { entries: T[]; changed: boolean } =>
+  snapEntriesToGrid(entries, { gridTicks, toleranceTicks, isEligible: () => true, keyOf })
+
+describe('snapTickToGrid', () => {
+  it('rounds to the nearest grid line', () => {
+    expect(snapTickToGrid(482, 120)).toBe(480)
+    expect(snapTickToGrid(540, 120)).toBe(600) // midpoint rounds up
+    expect(snapTickToGrid(7, 15)).toBe(0)
+    expect(snapTickToGrid(8, 15)).toBe(15)
+  })
+
+  it('returns the tick unchanged for a non-positive grid', () => {
+    expect(snapTickToGrid(123, 0)).toBe(123)
+  })
+})
+
+describe('gridTicksForDivision', () => {
+  it('computes grid spacing at 480 PPQ', () => {
+    expect(gridTicksForDivision(4)).toBe(120)
+    expect(gridTicksForDivision(32)).toBe(15)
+    expect(gridTicksForDivision(1)).toBe(480)
+  })
+})
+
+describe('snapEntriesToGrid', () => {
+  it('nudges a slightly-off note onto the nearest grid line', () => {
+    const notes = [mkNote({ tick: 482, lane: 'snare' })]
+    const { entries, changed } = snapAll(notes, 120, (n) => `${n.lane}|${n.tick}`)
+    expect(changed).toBe(true)
+    expect(entries[0].tick).toBe(480)
+  })
+
+  it('leaves genuinely off-grid notes untouched when within tolerance limits', () => {
+    // gridTicks 120, tolerance 25% = 30 ticks. A note at 540 is 60 ticks from
+    // either line (a real 1/8-label offbeat) and must NOT be dragged.
+    const gridTicks = gridTicksForDivision(4)
+    const tolerance = gridTicks * SNAP_TO_GRID_TOLERANCE_FRACTION
+    const notes = [mkNote({ tick: 540, lane: 'snare' })]
+    const { entries, changed } = snapAll(notes, gridTicks, (n) => `${n.lane}|${n.tick}`, tolerance)
+    expect(changed).toBe(false)
+    expect(entries[0].tick).toBe(540)
+  })
+
+  it('snaps a near-grid note but leaves a far one within the same pass', () => {
+    const gridTicks = gridTicksForDivision(4)
+    const tolerance = gridTicks * SNAP_TO_GRID_TOLERANCE_FRACTION
+    const notes = [
+      mkNote({ tick: 485, lane: 'snare' }), // 5 off -> snaps to 480
+      mkNote({ tick: 540, lane: 'yellowTom' }) // 60 off -> stays
+    ]
+    const { entries } = snapAll(notes, gridTicks, (n) => `${n.lane}|${n.tick}`, tolerance)
+    const snare = entries.find((n) => n.lane === 'snare')!
+    const tom = entries.find((n) => n.lane === 'yellowTom')!
+    expect(snare.tick).toBe(480)
+    expect(tom.tick).toBe(540)
+  })
+
+  it('de-duplicates notes that collapse onto the same position (issue #22)', () => {
+    // Two snare notes near tick 480 collapse onto 480 and must merge into one.
+    const notes = [
+      mkNote({ tick: 478, lane: 'snare', duration: 0 }),
+      mkNote({ tick: 482, lane: 'snare', duration: 0 })
+    ]
+    const { entries, changed } = snapAll(notes, 120, (n) => `${n.lane}|${n.tick}`)
+    expect(changed).toBe(true)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].tick).toBe(480)
+  })
+
+  it('keeps the longest sustain when collapsing duplicates', () => {
+    const notes = [
+      mkNote({ tick: 478, lane: 'snare', duration: 30 }),
+      mkNote({ tick: 482, lane: 'snare', duration: 200 })
+    ]
+    const { entries } = snapAll(notes, 120, (n) => `${n.lane}|${n.tick}`)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].duration).toBeGreaterThanOrEqual(200)
+  })
+
+  it('does not merge notes on different lanes at the same tick (chords survive)', () => {
+    const notes = [
+      mkNote({ tick: 482, lane: 'snare' }),
+      mkNote({ tick: 482, lane: 'yellowTom' })
+    ]
+    const { entries } = snapAll(notes, 120, (n) => `${n.lane}|${n.tick}`)
+    expect(entries).toHaveLength(2)
+    expect(entries.every((n) => n.tick === 480)).toBe(true)
+  })
+
+  it('re-aligns sustain ends so durations stay clean', () => {
+    const notes = [mkNote({ tick: 482, lane: 'green', duration: 236 })] // ends at 718
+    const { entries } = snapAll(notes, 120, (n) => `${n.lane}|${n.tick}`)
+    expect(entries[0].tick).toBe(480)
+    // 718 -> nearest 120 grid line is 720, so duration becomes 240.
+    expect(entries[0].duration).toBe(240)
+  })
+
+  it('only snaps eligible (selected) entries', () => {
+    const notes = [
+      mkNote({ tick: 482, lane: 'snare', id: 'sel' }),
+      mkNote({ tick: 482, lane: 'snare', id: 'other' })
+    ]
+    const selected = new Set(['sel'])
+    const { entries } = snapEntriesToGrid(notes, {
+      gridTicks: 120,
+      toleranceTicks: Infinity,
+      isEligible: (n) => selected.has(n.id),
+      keyOf: (n) => `${n.lane}|${n.tick}`
+    })
+    const sel = entries.find((n) => n.id === 'sel')!
+    const other = entries.find((n) => n.id === 'other')!
+    expect(sel.tick).toBe(480)
+    expect(other.tick).toBe(482)
+  })
+
+  it('reports no change when nothing needs snapping', () => {
+    const notes = [mkNote({ tick: 480, lane: 'snare' })]
+    const { entries, changed } = snapAll(notes, 120, (n) => `${n.lane}|${n.tick}`)
+    expect(changed).toBe(false)
+    expect(entries).toBe(notes)
+  })
+})

--- a/src/renderer/src/utils/snapToGrid.ts
+++ b/src/renderer/src/utils/snapToGrid.ts
@@ -1,0 +1,101 @@
+import { TICKS_PER_BEAT } from '../types'
+
+/**
+ * Snapping fraction used by the manual "Snap to Grid" action: a note is only
+ * pulled onto a grid line when it already lies within this fraction of the grid
+ * spacing of that line. Notes nearer the middle of a cell (a genuine finer
+ * subdivision — syncopation, fills, or an intentional off-beat hit) are left
+ * exactly where they are. This mirrors the auto-chart drum-snap behaviour
+ * ("nudge onset jitter onto the grid, leave genuinely off-grid hits untouched")
+ * and fixes issue #22, where coarse snapping dragged correctly-placed notes off
+ * their subdivision.
+ */
+export const SNAP_TO_GRID_TOLERANCE_FRACTION = 0.25
+
+/** Snap a single tick value to the nearest grid line of the given spacing. */
+export function snapTickToGrid(tick: number, gridTicks: number): number {
+  if (gridTicks <= 0) return tick
+  return Math.round(tick / gridTicks) * gridTicks
+}
+
+/** Grid-line spacing in ticks for a snap division (e.g. 4 → 120 ticks at 480 PPQ). */
+export function gridTicksForDivision(division: number): number {
+  return TICKS_PER_BEAT / division
+}
+
+export interface SnapEntriesOptions<T> {
+  /** Spacing between grid lines, in ticks. */
+  gridTicks: number
+  /**
+   * A note is only moved when its distance to the nearest grid line is `<=` this
+   * many ticks. Pass `Infinity` to snap every eligible note to its nearest line.
+   */
+  toleranceTicks: number
+  /** Whether an entry is eligible to be snapped (e.g. a selection filter). */
+  isEligible: (entry: T) => boolean
+  /**
+   * De-duplication key for an entry at its (possibly snapped) position. When two
+   * entries share a key, only the one with the longest sustain is kept, so
+   * snapping never silently stacks notes on top of each other (issue #22).
+   */
+  keyOf: (entry: T) => string
+}
+
+export interface SnapEntriesResult<T> {
+  entries: T[]
+  changed: boolean
+}
+
+/**
+ * Snap a list of tick-based entries onto the grid and collapse any entries that
+ * land on the same logical position.
+ *
+ * Eligible entries within `toleranceTicks` of a grid line are nudged onto it
+ * (their sustain end is re-aligned too, so durations stay clean); entries that
+ * are further out, ineligible, or already on the grid keep their exact tick.
+ * After snapping, entries that now share a `keyOf` value are de-duplicated,
+ * keeping the longest sustain. The returned list preserves first-seen order.
+ */
+export function snapEntriesToGrid<T extends { tick: number; duration: number }>(
+  entries: T[],
+  options: SnapEntriesOptions<T>
+): SnapEntriesResult<T> {
+  const { gridTicks, toleranceTicks, isEligible, keyOf } = options
+  if (gridTicks <= 0) return { entries, changed: false }
+
+  let changed = false
+
+  const snapped = entries.map((entry) => {
+    if (!isEligible(entry)) return entry
+    const newTick = snapTickToGrid(entry.tick, gridTicks)
+    const delta = newTick - entry.tick
+    if (delta === 0 || Math.abs(delta) > toleranceTicks) return entry
+
+    let newDuration = entry.duration
+    if (entry.duration > 0) {
+      newDuration = Math.max(0, snapTickToGrid(entry.tick + entry.duration, gridTicks) - newTick)
+    }
+    if (newTick === entry.tick && newDuration === entry.duration) return entry
+
+    changed = true
+    return { ...entry, tick: newTick, duration: newDuration }
+  })
+
+  // Collapse entries that now share a position, keeping the longest sustain.
+  const byKey = new Map<string, T>()
+  const order: string[] = []
+  for (const entry of snapped) {
+    const key = keyOf(entry)
+    const existing = byKey.get(key)
+    if (!existing) {
+      byKey.set(key, entry)
+      order.push(key)
+    } else {
+      if (entry.duration > existing.duration) byKey.set(key, entry)
+      changed = true
+    }
+  }
+
+  if (!changed) return { entries, changed: false }
+  return { entries: order.map((key) => byKey.get(key)!), changed: true }
+}


### PR DESCRIPTION
Promote `beta` to `master`.

## Included
- **#21** — Refresh folder button in the Project Explorer (cleans up stale song stores on reload/refresh).
- **#20** — Async chart validation engine with visual preview card, drum hand-assignment/physicality checks, quick fixes ("Clean Up All Duplicates"), and validation preferences in Settings.
- **#26** — Fix for **#22**: `Snap to Grid` is now non-destructive — it only nudges notes already near a grid line (off-grid notes are left untouched) and de-duplicates notes that collapse onto the same position instead of silently stacking them.

## Verification
- `typecheck` clean; full suite of 30 unit tests passes.
- All included PRs passed CI on `beta`.
