### PR TITLE
Release: republish v1.0.18 with fixed tag job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,16 @@ jobs:
           git add package.json package-lock.json
           git commit -m "release: ${{ steps.bump.outputs.tag }}" || true
           git tag ${{ steps.bump.outputs.tag }}
-          git push origin master --tags
+          # `master` is a protected branch (changes must go through a PR), so we
+          # push ONLY the tag — never the branch. The version-bump commit is the
+          # tag's target, which is exactly what the build job checks out
+          # (`ref: ${{ steps.bump.outputs.tag }}`), so the packaged app still
+          # reports the right version. Pushing `master --tags` here used to be
+          # rejected by branch protection ("Changes must be made through a pull
+          # request"), which aborted the release after the tag was created but
+          # before any installers / latest.yml were published — leaving a
+          # phantom tag with no assets that broke auto-update for everyone.
+          git push origin "${{ steps.bump.outputs.tag }}"
 
   build:
     needs: tag


### PR DESCRIPTION
Promotes the release-workflow fix (#28) to master so the Build & Release pipeline can complete. The previous beta->master merge created a phantom v1.0.18 tag (branch-protection rejected the tag job's direct push to master) with no assets, breaking auto-update. The fixed job pushes only the tag, so this merge will produce a real v1.0.18 release with installers and latest.yml.