### PR TITLE
Fix macOS paste shortcuts

### DIFF
--- a/src/main/applicationMenu.test.ts
+++ b/src/main/applicationMenu.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { MenuItemConstructorOptions } from 'electron'
+import { createApplicationMenuTemplate } from './applicationMenu'
+
+describe('application menu', () => {
+  it('registers native editing roles so macOS forwards shortcuts to focused inputs', () => {
+    const template = createApplicationMenuTemplate({
+      version: '1.0.0',
+      sendCommand: vi.fn(),
+      openExternal: vi.fn()
+    })
+    const editMenu = template.find((item) => item.label === 'Edit')
+    const submenu = editMenu?.submenu as MenuItemConstructorOptions[]
+
+    expect(submenu.map((item) => item.role).filter(Boolean)).toEqual([
+      'undo',
+      'redo',
+      'cut',
+      'copy',
+      'paste',
+      'selectAll'
+    ])
+  })
+})

--- a/src/main/applicationMenu.ts
+++ b/src/main/applicationMenu.ts
@@ -1,0 +1,108 @@
+import type { MenuItemConstructorOptions } from 'electron'
+
+type ApplicationMenuOptions = {
+  version: string
+  sendCommand: (command: string, payload?: unknown) => void
+  openExternal: (url: string) => void
+}
+
+export function createApplicationMenuTemplate({
+  version,
+  sendCommand,
+  openExternal
+}: ApplicationMenuOptions): MenuItemConstructorOptions[] {
+  return [
+    {
+      label: 'File',
+      submenu: [
+        {
+          label: 'New',
+          accelerator: 'CmdOrCtrl+N',
+          click: () => sendCommand('file:new-song')
+        },
+        {
+          label: 'Open',
+          accelerator: 'CmdOrCtrl+O',
+          click: () => sendCommand('file:open-folder')
+        },
+        { type: 'separator' },
+        {
+          label: 'Settings',
+          accelerator: 'CmdOrCtrl+,',
+          click: () => sendCommand('file:open-settings')
+        }
+      ]
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo', label: 'Undo' },
+        { role: 'redo', label: 'Redo' },
+        { type: 'separator' },
+        { role: 'cut', label: 'Cut' },
+        { role: 'copy', label: 'Copy' },
+        { role: 'paste', label: 'Paste' },
+        { role: 'selectAll', label: 'Select All' }
+      ]
+    },
+    {
+      label: 'View',
+      submenu: [
+        {
+          label: 'File Explorer',
+          type: 'checkbox',
+          checked: true,
+          click: (item) =>
+            sendCommand('view:toggle-panel', { panel: 'explorer', visible: item.checked })
+        },
+        {
+          label: 'Preview',
+          type: 'checkbox',
+          checked: true,
+          click: (item) =>
+            sendCommand('view:toggle-panel', { panel: 'preview', visible: item.checked })
+        },
+        {
+          label: 'Properties',
+          type: 'checkbox',
+          checked: true,
+          click: (item) =>
+            sendCommand('view:toggle-panel', { panel: 'properties', visible: item.checked })
+        },
+        { type: 'separator' },
+        {
+          label: 'Piano Roll',
+          type: 'checkbox',
+          checked: true,
+          click: (item) =>
+            sendCommand('view:toggle-panel', { panel: 'midi', visible: item.checked })
+        },
+        {
+          label: 'Timeline',
+          type: 'checkbox',
+          checked: true,
+          click: (item) =>
+            sendCommand('view:toggle-panel', { panel: 'video', visible: item.checked })
+        }
+      ]
+    },
+    {
+      label: 'Help',
+      submenu: [
+        {
+          label: `Version ${version}`,
+          enabled: false
+        },
+        { type: 'separator' },
+        {
+          label: 'GitHub Repository',
+          click: () => openExternal('https://github.com/opria123/octave')
+        },
+        {
+          label: 'Support',
+          click: () => openExternal('https://github.com/opria123/octave/issues')
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, shell, BrowserWindow, ipcMain, dialog, protocol, net, Menu, session, type MenuItemConstructorOptions } from 'electron'
+import { app, shell, BrowserWindow, ipcMain, dialog, protocol, net, Menu, session } from 'electron'
 import { join, resolve, basename } from 'path'
 import { readdir, readFile, writeFile, stat, rename, copyFile, unlink, mkdir } from 'fs/promises'
 import { existsSync, readFileSync } from 'fs'
@@ -11,6 +11,7 @@ import ffmpeg from 'fluent-ffmpeg'
 import { cancelAutoChart, getStrumRequirementsPath, killAllRunningJobs, openStrumLogsFolder, resolvePythonCommand, runAutoChart } from './strumIntegration/runner'
 import { ensureBootstrappedPython, getRuntimeStatus, isBootstrapTarget } from './strumIntegration/runtimeBootstrap'
 import { packSng } from './sngPacker'
+import { createApplicationMenuTemplate } from './applicationMenu'
 
 // Point fluent-ffmpeg at the bundled static binary
 try {
@@ -252,94 +253,13 @@ function sendMenuCommand(command: string, payload?: unknown): void {
 }
 
 function createApplicationMenu(): void {
-  const template: MenuItemConstructorOptions[] = [
-    {
-      label: 'File',
-      submenu: [
-        {
-          label: 'New',
-          accelerator: 'CmdOrCtrl+N',
-          click: () => sendMenuCommand('file:new-song')
-        },
-        {
-          label: 'Open',
-          accelerator: 'CmdOrCtrl+O',
-          click: () => sendMenuCommand('file:open-folder')
-        },
-        { type: 'separator' },
-        {
-          label: 'Settings',
-          accelerator: 'CmdOrCtrl+,',
-          click: () => sendMenuCommand('file:open-settings')
-        }
-      ]
-    },
-    {
-      label: 'Edit',
-      submenu: [
-        { role: 'undo', label: 'Undo' },
-        { role: 'redo', label: 'Redo' }
-      ]
-    },
-    {
-      label: 'View',
-      submenu: [
-        {
-          label: 'File Explorer',
-          type: 'checkbox',
-          checked: true,
-          click: (item) => sendMenuCommand('view:toggle-panel', { panel: 'explorer', visible: item.checked })
-        },
-        {
-          label: 'Preview',
-          type: 'checkbox',
-          checked: true,
-          click: (item) => sendMenuCommand('view:toggle-panel', { panel: 'preview', visible: item.checked })
-        },
-        {
-          label: 'Properties',
-          type: 'checkbox',
-          checked: true,
-          click: (item) => sendMenuCommand('view:toggle-panel', { panel: 'properties', visible: item.checked })
-        },
-        { type: 'separator' },
-        {
-          label: 'Piano Roll',
-          type: 'checkbox',
-          checked: true,
-          click: (item) => sendMenuCommand('view:toggle-panel', { panel: 'midi', visible: item.checked })
-        },
-        {
-          label: 'Timeline',
-          type: 'checkbox',
-          checked: true,
-          click: (item) => sendMenuCommand('view:toggle-panel', { panel: 'video', visible: item.checked })
-        }
-      ]
-    },
-    {
-      label: 'Help',
-      submenu: [
-        {
-          label: `Version ${app.getVersion()}`,
-          enabled: false
-        },
-        { type: 'separator' },
-        {
-          label: 'GitHub Repository',
-          click: () => {
-            void shell.openExternal('https://github.com/opria123/octave')
-          }
-        },
-        {
-          label: 'Support',
-          click: () => {
-            void shell.openExternal('https://github.com/opria123/octave/issues')
-          }
-        }
-      ]
+  const template = createApplicationMenuTemplate({
+    version: app.getVersion(),
+    sendCommand: sendMenuCommand,
+    openExternal: (url) => {
+      void shell.openExternal(url)
     }
-  ]
+  })
 
   const menu = Menu.buildFromTemplate(template)
   Menu.setApplicationMenu(menu)


### PR DESCRIPTION
## What changed

- restore native Cut, Copy, Paste, and Select All roles in the Electron Edit menu
- extract the application menu template into a testable module
- add a regression test for the standard native editing roles

## Root cause

OCTAVE replaces Electron’s default application menu, but the custom Edit menu only registered Undo and Redo. On macOS, Command-key editing shortcuts are handled through native application-menu roles, so Command+V never reached focused text inputs such as the auto-chart URL field. Linux still delivered Ctrl+V through Chromium, masking the missing menu configuration.

## Impact

Paste and the other standard editing shortcuts now work in focused text controls on macOS while preserving OCTAVE’s custom chart-editor shortcuts outside inputs.

## Validation

- `npm test` (31 tests)
- `npm run typecheck`
- `npm run build`
- `npx eslint src/main/applicationMenu.ts src/main/applicationMenu.test.ts`