### PR TITLE
fix: stems fail to load after Electron 39.8 upgrade (song-file CORS)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -292,7 +292,11 @@ function createApplicationMenu(): void {
 protocol.registerSchemesAsPrivileged([
   {
     scheme: 'song-file',
-    privileges: { stream: true, supportFetchAPI: true }
+    // corsEnabled + the Access-Control-Allow-Origin header in the handler are
+    // required for fetch() from the file:// renderer origin: Chromium in
+    // Electron >= 39.3 blocks cross-origin fetches to custom schemes that are
+    // not CORS-enabled (stems stopped loading after the 39.8 upgrade, #34).
+    privileges: { stream: true, supportFetchAPI: true, corsEnabled: true }
   }
 ])
 
@@ -326,7 +330,18 @@ app.whenReady().then(() => {
     // On macOS/Linux paths start with /, so file:// + /path = file:///path (correct)
     // On Windows we need file:/// + C:/path
     const fileUrl = normalized.startsWith('/') ? `file://${normalized}` : `file:///${normalized}`
-    return net.fetch(fileUrl)
+    return net.fetch(fileUrl).then((response) => {
+      // The renderer's file:// origin makes every song-file fetch cross-origin,
+      // so the response must carry an explicit CORS grant (see
+      // registerSchemesAsPrivileged above).
+      const headers = new Headers(response.headers)
+      headers.set('Access-Control-Allow-Origin', '*')
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers
+      })
+    })
   })
 
   // Default open or close DevTools by F12 in development


### PR DESCRIPTION
## Summary

Fixes #34 — since v1.0.19, no audio stems load for any song. The last release bumped Electron from 39.2.6 to 39.8.10, and Chromium in 39.8.x now blocks `fetch()` from the `file://` renderer origin to custom protocol schemes that are not CORS-enabled. Every `song-file://` stem request failed with:

```
Access to fetch at 'song-file://...' from origin 'file://' has been blocked by CORS policy
```

`loadAudio` caught the error and songs loaded silently with no audio — exactly the symptom in the issue.

## Fix

- Register the `song-file` scheme with `corsEnabled: true`
- Attach an explicit `Access-Control-Allow-Origin: *` header to protocol responses

Path access is unchanged — the handler still rejects anything outside `allowedProjectPath`.

## Verification

Drove the built app with the Playwright harness (`scripts/screenshots/lib/setup.mjs`) against a fixture song with three ogg stems, running the identical app build under both Electron binaries:

| Electron | Before fix | After fix |
|---|---|---|
| 39.2.6 (v1.0.18 runtime) | ✅ stems load | ✅ stems load |
| 39.8.10 (v1.0.19 runtime) | ❌ all stems CORS-blocked | ✅ stems load |

Tests (73), typecheck (node + web), and lint on the changed file all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)