### PR TITLE
fix: BRE and drum roll markers lost on save/reload

### DIFF
--- a/src/renderer/src/utils/midiParser.test.ts
+++ b/src/renderer/src/utils/midiParser.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { parseMidiBase64, serializeMidiBase64 } from './midiParser'
-import type { Note } from '../types'
+import { parseMidiBase64, serializeMidiBase64, parseChartFile, serializeChartFile } from './midiParser'
+import type { LaneMarker, Note } from '../types'
 
 // Issue #12: open frets and tap notes reverted to green/strums after a
 // save → reopen round-trip because serializeMidiBase64 dropped them.
@@ -58,5 +58,76 @@ describe('open fret / tap note MIDI round-trip', () => {
     )
     expect(twice.notes.find((n) => n.tick === 0)?.lane).toBe('open')
     expect(twice.notes.find((n) => n.tick === 480)?.flags?.isTap).toBe(true)
+  })
+})
+
+// Issue #37: BRE sections and drum rolls disappeared after a save → reopen
+// round-trip because both serializers dropped lane markers entirely.
+describe('lane marker round-trip', () => {
+  const tempo = [{ tick: 0, bpm: 120 }]
+  const timeSig = [{ tick: 0, numerator: 4, denominator: 4 }]
+  const mkNote = (over: Partial<Note>): Note => ({
+    id: 'x',
+    tick: 0,
+    duration: 120,
+    instrument: 'guitar',
+    difficulty: 'expert',
+    lane: 'green',
+    velocity: 100,
+    ...over
+  })
+  const mkMarker = (over: Partial<LaneMarker>): LaneMarker => ({
+    id: 'm',
+    tick: 960,
+    duration: 480,
+    instrument: 'drums',
+    type: 'drumRoll',
+    ...over
+  })
+  // The serializers only emit tracks that contain notes, so seed one per instrument.
+  const notes: Note[] = [
+    mkNote({ instrument: 'drums', lane: 'kick' }),
+    mkNote({ instrument: 'guitar', lane: 'green' })
+  ]
+
+  const findMarker = (
+    markers: LaneMarker[],
+    instrument: string,
+    type: string
+  ): LaneMarker | undefined =>
+    markers.find((m) => m.instrument === instrument && m.type === type)
+
+  it('preserves BRE and drum roll markers across MIDI serialize → parse', () => {
+    const markers: LaneMarker[] = [
+      mkMarker({ tick: 960, type: 'drumRoll' }),
+      mkMarker({ tick: 1920, type: 'bre' }),
+      mkMarker({ tick: 960, instrument: 'guitar', type: 'tremolo' }),
+      mkMarker({ tick: 1920, instrument: 'guitar', type: 'trill' }),
+      mkMarker({ tick: 2880, instrument: 'guitar', type: 'bre' })
+    ]
+    const parsed = parseMidiBase64(
+      serializeMidiBase64(notes, tempo, timeSig, 480, [], [], [], [], [], markers)
+    )
+
+    expect(findMarker(parsed.laneMarkers, 'drums', 'drumRoll')).toMatchObject({ tick: 960, duration: 480 })
+    expect(findMarker(parsed.laneMarkers, 'drums', 'bre')).toMatchObject({ tick: 1920, duration: 480 })
+    expect(findMarker(parsed.laneMarkers, 'guitar', 'tremolo')).toMatchObject({ tick: 960 })
+    expect(findMarker(parsed.laneMarkers, 'guitar', 'trill')).toMatchObject({ tick: 1920 })
+    expect(findMarker(parsed.laneMarkers, 'guitar', 'bre')).toMatchObject({ tick: 2880 })
+    // The BRE companion notes (121-124) must not leak into playable notes.
+    expect(parsed.notes).toHaveLength(notes.length)
+  })
+
+  it('preserves drum fill/roll markers across .chart serialize → parse', () => {
+    const markers: LaneMarker[] = [
+      mkMarker({ tick: 960, type: 'drumRoll' }),
+      mkMarker({ tick: 1920, type: 'bre' })
+    ]
+    const parsed = parseChartFile(
+      serializeChartFile(notes, tempo, timeSig, [], [], [], [], [], {}, 192, markers)
+    )
+
+    expect(findMarker(parsed.laneMarkers, 'drums', 'drumRoll')).toMatchObject({ tick: 960, duration: 480 })
+    expect(findMarker(parsed.laneMarkers, 'drums', 'bre')).toMatchObject({ tick: 1920, duration: 480 })
   })
 })

--- a/src/renderer/src/utils/midiParser.ts
+++ b/src/renderer/src/utils/midiParser.ts
@@ -481,11 +481,15 @@ export function parseMidiBase64(midiBase64: string): ParsedMidiData {
         continue
       }
 
-      // Lane markers
+      // Lane markers. RB/CH .mid convention: notes 120-124 mark a BRE / drum
+      // fill across all five lanes (120 carries the marker, 121-124 are its
+      // companions); on PART DRUMS 126/127 are single/double drum rolls while
+      // on other instruments 126 is tremolo and 127 is trill.
       let laneMarkerType: LaneMarkerType | null = null
-      if (noteNumber === 126) laneMarkerType = 'trill'
-      else if (noteNumber === 127) laneMarkerType = 'tremolo'
-      else if (noteNumber === 120 && (instrument === 'drums')) laneMarkerType = 'bre'
+      if (noteNumber === 126) laneMarkerType = instrument === 'drums' ? 'drumRoll' : 'tremolo'
+      else if (noteNumber === 127) laneMarkerType = instrument === 'drums' ? 'drumRoll' : 'trill'
+      else if (noteNumber === 120) laneMarkerType = 'bre'
+      else if (noteNumber >= 121 && noteNumber <= 124) continue // BRE companion lanes of 120
       else if (noteNumber === 103 && (instrument === 'drums')) laneMarkerType = 'discoFlip'
       else if (noteNumber === 65 && (instrument === 'drums')) laneMarkerType = 'drumRoll'
       if (laneMarkerType) {
@@ -1168,6 +1172,20 @@ export function parseChartFile(chartText: string): ParsedMidiData {
         continue
       }
 
+      // Drum lane markers: S 64 = fill/BRE, S 65 = drum roll, S 66 = double
+      // drum roll. Read from the expert section only — mirrors how they are
+      // written and avoids duplicates when charts repeat them per difficulty.
+      if (type === 'drums' && difficulty === 'expert') {
+        const specialMatch = line.match(/^\s*(\d+)\s*=\s*S\s+(6[456])\s+(\d+)/)
+        if (specialMatch) {
+          const tick = Math.round(parseInt(specialMatch[1], 10) * tickScale)
+          const duration = Math.round(parseInt(specialMatch[3], 10) * tickScale)
+          const markerType: LaneMarkerType = specialMatch[2] === '64' ? 'bre' : 'drumRoll'
+          laneMarkers.push({ id: uuidv4(), tick, duration, instrument, type: markerType })
+          continue
+        }
+      }
+
       // Solo: tick = E solo / tick = E soloend (some charts)
       // Also check for solo markers via S type (less common)
     }
@@ -1274,7 +1292,7 @@ export function serializeChartFile(
   songSections: SongSection[] = [],
   metadata: Record<string, unknown> = {},
   resolution = 192,
-  _laneMarkers: LaneMarker[] = [],
+  laneMarkers: LaneMarker[] = [],
   venueTrack: VenueTrackData = createEmptyVenueTrack()
 ): string {
   const tickScale = resolution / 480 // Convert from internal 480 PPQ to chart resolution
@@ -1421,6 +1439,18 @@ export function serializeChartFile(
         const duration = scaleTick(sp.duration)
         entries.push({ tick, text: `${tick} = S 2 ${duration}` })
       }
+      // Drum lane markers: .chart encodes a fill/BRE as S 64 and a drum roll
+      // as S 65. Trill/tremolo/disco flip have no .chart representation.
+      if (isDrums) {
+        for (const marker of laneMarkers) {
+          if (marker.instrument !== instrument) continue
+          const specialCode = marker.type === 'bre' ? 64 : marker.type === 'drumRoll' ? 65 : null
+          if (specialCode === null) continue
+          const tick = scaleTick(marker.tick)
+          const duration = scaleTick(marker.duration)
+          entries.push({ tick, text: `${tick} = S ${specialCode} ${duration}` })
+        }
+      }
     }
 
     // Sort by tick
@@ -1485,7 +1515,7 @@ export function serializeMidiBase64(
   vocalPhrases: VocalPhrase[] = [],
   soloSections: SoloSection[] = [],
   songSections: SongSection[] = [],
-  _laneMarkers: LaneMarker[] = [],
+  laneMarkers: LaneMarker[] = [],
   venueTrack: VenueTrackData = createEmptyVenueTrack()
 ): string {
   const midi = new Midi()
@@ -1605,6 +1635,22 @@ export function serializeMidiBase64(
             durationTicks: Math.max(solo.duration, 1),
             velocity: 1.0
           })
+        }
+      }
+      // Lane markers (see the parse-side mapping): BRE spans notes 120-124,
+      // drum rolls are 126 on PART DRUMS, tremolo/trill are 126/127 elsewhere.
+      // Disco flip has no note representation (it's a [mix N drums0d] text
+      // event) and is not serialized yet.
+      for (const marker of laneMarkers) {
+        if (marker.instrument !== instrumentName || marker.type === 'discoFlip') continue
+        const durationTicks = Math.max(marker.duration, 1)
+        if (marker.type === 'bre') {
+          for (let breNote = 120; breNote <= 124; breNote++) {
+            track.addNote({ midi: breNote, ticks: marker.tick, durationTicks, velocity: 1.0 })
+          }
+        } else {
+          const markerNote = marker.type === 'trill' && instrumentName !== 'drums' ? 127 : 126
+          track.addNote({ midi: markerNote, ticks: marker.tick, durationTicks, velocity: 1.0 })
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes #37 — adding a BRE (or drum roll / trill / tremolo) and saving lost the marker on the next load. Both `serializeMidiBase64` and `serializeChartFile` accepted `laneMarkers` but silently ignored them (the parameters were literally named `_laneMarkers`), so the parse side had nothing to read back.

## Changes

**MIDI (.mid)**
- Serialize lane markers, following the RB/CH conventions: BRE = notes 120–124 on every instrument, drum rolls = 126 on PART DRUMS, tremolo/trill = 126/127 on other instruments.
- Parser updates to match the spec: BRE (120) now recognized on all instruments, not just drums; 121–124 explicitly skipped as BRE companion lanes; on drums 126/127 parse as drum rolls; on other instruments 126/127 previously had tremolo and trill **swapped** vs. the RBN convention — now corrected. Legacy note 65 still parses as a drum roll.

**.chart**
- Serialize + parse the standard specials in the expert drums section: `S 64` = fill/BRE, `S 65`/`S 66` = drum roll.

**Known remaining gap:** disco flip is a `[mix N drums0d]` text event in the .mid spec and still isn't serialized (it was never round-trippable — its old parse branch at note 103 was dead code, shadowed by the solo-section check). Left for a follow-up so this fix stays scoped.

## Verification

- New round-trip tests: `serialize → parse` preserves BRE + drum roll on drums and trill/tremolo/BRE on guitar for .mid, and fill/roll markers for .chart; BRE companion notes don't leak into playable notes.
- Full suite: 75/75 tests pass; typecheck (node + web) passes; the change removes 2 pre-existing lint errors and adds none.
- Save/load call sites (Toolbar save, autosave, ProjectExplorer load) already pass `laneMarkers` through — no renderer changes needed beyond the parser module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)