### PR TITLE
fix: relocate bundled macOS demucs dylibs

### DIFF
--- a/.github/workflows/demucs-cpp-binaries.yml
+++ b/.github/workflows/demucs-cpp-binaries.yml
@@ -20,13 +20,14 @@ on:
         required: false
         default: 'main'
   push:
-    branches: [master, main]
+    branches: [master, main, beta]
     paths:
       - '.github/workflows/demucs-cpp-binaries.yml'
       - 'src/main/strumIntegration/demucsCppBootstrap.ts'
+      - 'scripts/bundle_macos_dylibs.py'
 
 env:
-  BIN_VERSION: '2'
+  BIN_VERSION: '3'
   UPSTREAM_REPO: 'sevagh/demucs.cpp'
   UPSTREAM_REF: ${{ github.event.inputs.upstream_ref || 'main' }}
 
@@ -263,13 +264,11 @@ jobs:
               fi
             done
           elif [ "${{ matrix.platform }}" = "darwin" ]; then
-            # Copy libomp + openblas dylibs and rewrite RPATH to look in the
-            # tarball's own directory.
-            for dylib_dir in "$LIBOMP_PATH/lib" "$OPENBLAS_PATH/lib"; do
-              cp "$dylib_dir"/libomp*.dylib staged/ 2>/dev/null || true
-              cp "$dylib_dir"/libopenblas*.dylib staged/ 2>/dev/null || true
-            done
-            install_name_tool -add_rpath "@executable_path" "staged/${{ matrix.exe }}" || true
+            python3 scripts/test_bundle_macos_dylibs.py
+            python3 scripts/bundle_macos_dylibs.py "staged/${{ matrix.exe }}" \
+              --search "$OPENBLAS_PATH/lib" \
+              --search "$LIBOMP_PATH/lib" \
+              --search "$(brew --prefix gcc)/lib/gcc/current"
           fi
 
       - name: Create tarball
@@ -281,7 +280,7 @@ jobs:
           echo "ASSET=$ASSET" >> "$GITHUB_ENV"
 
       - name: Ensure release exists
-        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
@@ -295,7 +294,7 @@ jobs:
           fi
 
       - name: Upload to release
-        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash

--- a/scripts/bundle_macos_dylibs.py
+++ b/scripts/bundle_macos_dylibs.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Close, relocate, and ad-hoc-sign a staged macOS Mach-O dependency graph."""
+
+import argparse
+import re
+import shutil
+import subprocess
+from collections import deque
+from pathlib import Path
+
+SYSTEM_PREFIXES = ("/System/Library/", "/usr/lib/")
+
+
+class BundleError(RuntimeError):
+    pass
+
+
+def command(args, allow_failure=False):
+    result = subprocess.run(args, text=True, capture_output=True)
+    if result.returncode and not allow_failure:
+        detail = (result.stderr or result.stdout).strip()
+        raise BundleError(f"{' '.join(args)} failed ({result.returncode}): {detail}")
+    return result.stdout
+
+
+def dylib_id(path):
+    lines = command(["otool", "-D", str(path)], allow_failure=True).splitlines()[1:]
+    return next((line.strip() for line in lines if line.strip()), None)
+
+
+def dependencies(path):
+    own_id = dylib_id(path)
+    result = []
+    for line in command(["otool", "-L", str(path)]).splitlines()[1:]:
+        dependency = line.strip().split(" (", 1)[0]
+        if dependency and dependency != own_id:
+            result.append(dependency)
+    return result
+
+
+def rpaths(path):
+    lines = command(["otool", "-l", str(path)]).splitlines()
+    result = []
+    for index, line in enumerate(lines):
+        if line.strip() != "cmd LC_RPATH":
+            continue
+        for candidate in lines[index + 1:index + 5]:
+            match = re.match(r"\s*path (.+) \(offset \d+\)$", candidate)
+            if match:
+                result.append(match.group(1))
+                break
+    return result
+
+
+def expand(value, loader, executable):
+    for token, base in (("@loader_path", loader.parent), ("@executable_path", executable.parent)):
+        if value == token:
+            return base.resolve()
+        if value.startswith(token + "/"):
+            return (base / value[len(token) + 1:]).resolve()
+    return Path(value).resolve() if value.startswith("/") else None
+
+
+def unique_existing(paths):
+    return sorted({path.resolve() for path in paths if path.is_file()}, key=str)
+
+
+def resolve_dependency(dependency, loader, executable, loader_rpaths, searches):
+    if dependency.startswith(SYSTEM_PREFIXES):
+        return None
+    direct = []
+    if dependency.startswith("@rpath/"):
+        suffix = dependency[len("@rpath/"):]
+        for entry in loader_rpaths:
+            base = expand(entry, loader, executable)
+            if base is not None:
+                direct.append(base / suffix)
+    else:
+        resolved = expand(dependency, loader, executable)
+        direct.append(resolved if resolved is not None else loader.parent / dependency)
+    candidates = unique_existing(direct)
+    if not candidates:
+        candidates = unique_existing(directory / Path(dependency).name for directory in searches)
+    if len(candidates) != 1:
+        state = "missing" if not candidates else "ambiguous: " + ", ".join(map(str, candidates))
+        raise BundleError(f"cannot resolve {dependency} from {loader}: {state}")
+    return candidates[0]
+
+
+def close_graph(executable, searches):
+    executable = executable.resolve()
+    stage = executable.parent
+    if not executable.is_file():
+        raise BundleError(f"staged executable does not exist: {executable}")
+    for directory in searches:
+        if not directory.is_dir():
+            raise BundleError(f"search directory does not exist: {directory}")
+
+    queue = deque([(executable, executable)])
+    seen, changed, bundled = set(), set(), set()
+    owners = {executable.name: executable}
+    while queue:
+        origin, current = queue.popleft()
+        current = current.resolve()
+        if current in seen:
+            continue
+        seen.add(current)
+        current_rpaths = rpaths(origin)
+        for dependency in dependencies(origin):
+            source = resolve_dependency(dependency, origin, executable, current_rpaths, searches)
+            if source is None:
+                continue
+            name = Path(dependency).name
+            if not name or "/" in name:
+                raise BundleError(f"invalid dependency basename: {dependency}")
+            destination = stage / name
+            prior = owners.get(name)
+            source_real = source.resolve()
+            destination_real = destination.resolve() if destination.exists() else None
+            if prior is not None and source_real not in (prior, destination_real):
+                raise BundleError(f"basename collision for {name}: {prior} vs {source_real}")
+            if prior is None:
+                if destination.exists() and source_real != destination_real:
+                    raise BundleError(f"destination collision for {name}: {destination}")
+                owners[name] = source_real
+                if source_real != destination_real:
+                    shutil.copy2(source_real, destination)
+                command(["install_name_tool", "-id", f"@loader_path/{name}", str(destination)])
+                changed.add(destination.resolve())
+                bundled.add(destination.resolve())
+                queue.append((source_real, destination))
+            relocated = f"@loader_path/{name}"
+            if dependency != relocated:
+                command(["install_name_tool", "-change", dependency, relocated, str(current)])
+                changed.add(current)
+
+    for path in sorted(seen, key=str):
+        if path in bundled and dylib_id(path) != f"@loader_path/{path.name}":
+            raise BundleError(f"dylib ID was not normalized: {path}")
+        for dependency in dependencies(path):
+            if dependency.startswith(SYSTEM_PREFIXES):
+                continue
+            prefix = "@loader_path/"
+            name = dependency[len(prefix):] if dependency.startswith(prefix) else ""
+            if not name or "/" in name or not (stage / name).is_file():
+                raise BundleError(f"non-closed dependency in {path}: {dependency}")
+
+    for path in sorted(changed, key=str):
+        command(["codesign", "--force", "--sign", "-", "--timestamp=none", str(path)])
+    for path in sorted(changed, key=str):
+        command(["codesign", "--verify", "--strict", str(path)])
+    print(f"bundled {len(bundled)} libraries; signed {len(changed)} Mach-O files")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("executable", type=Path)
+    parser.add_argument("--search", action="append", default=[], type=Path)
+    args = parser.parse_args()
+    try:
+        close_graph(args.executable, [path.resolve() for path in args.search])
+    except (BundleError, OSError) as error:
+        parser.exit(1, f"error: {error}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_bundle_macos_dylibs.py
+++ b/scripts/test_bundle_macos_dylibs.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+import contextlib
+import importlib.util
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location("bundler", Path(__file__).with_name("bundle_macos_dylibs.py"))
+bundler = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bundler)
+
+
+class FakeMachO:
+    def __init__(self, metadata):
+        self.metadata = metadata
+        self.signed, self.verified = [], []
+
+    def __call__(self, args, allow_failure=False):
+        tool, *rest = args
+        if tool == "otool":
+            mode, path = rest
+            item = self.metadata[Path(path).name]
+            if mode == "-D":
+                return f"{path}:\n" + (f"{item['id']}\n" if item.get("id") else "")
+            if mode == "-L":
+                deps = ([item["id"]] if item.get("id") else []) + item.get("deps", [])
+                return f"{path}:\n" + "".join(f"\t{dep} (compatibility version 1.0.0)\n" for dep in deps)
+            if mode == "-l":
+                return "".join(f"cmd LC_RPATH\npath {entry} (offset 12)\n" for entry in item.get("rpaths", []))
+        if tool == "install_name_tool":
+            operation, old, *tail = rest
+            if operation == "-id":
+                self.metadata[Path(tail[0]).name]["id"] = old
+            else:
+                new, path = tail
+                item = self.metadata[Path(path).name]
+                item["deps"] = [new if dep == old else dep for dep in item.get("deps", [])]
+            return ""
+        if tool == "codesign":
+            path = Path(rest[-1]).name
+            if "--verify" in rest:
+                if path not in self.signed:
+                    raise bundler.BundleError(f"verified before signing: {path}")
+                self.verified.append(path)
+            else:
+                self.signed.append(path)
+            return ""
+        raise AssertionError(args)
+
+
+class BundleTests(unittest.TestCase):
+    def touch(self, path, content=None):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content or path.name.encode())
+
+    def test_recursive_graph_resolves_all_path_forms_and_signs(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            stage, source, search, rpath = root / "stage", root / "source", root / "search", root / "rpath"
+            files = {
+                "app": stage / "app",
+                "libabs.dylib": source / "libabs.dylib",
+                "libloader.dylib": stage / "nested/libloader.dylib",
+                "libexec.dylib": stage / "exec/libexec.dylib",
+                "librpath.dylib": rpath / "librpath.dylib",
+                "libtransitive.dylib": source / "libtransitive.dylib",
+            }
+            for path in files.values():
+                self.touch(path)
+            self.touch(search / "librpath.dylib", b"rpath-fallback-must-not-win")
+            self.touch(search / "libtransitive.dylib", b"loader-fallback-must-not-win")
+            metadata = {
+                "app": {"deps": [str(files["libabs.dylib"]), "@loader_path/nested/libloader.dylib", "@executable_path/exec/libexec.dylib", "@rpath/librpath.dylib", "/usr/lib/libSystem.B.dylib"], "rpaths": [str(rpath)]},
+                "libabs.dylib": {"id": str(files["libabs.dylib"]), "deps": ["@loader_path/libtransitive.dylib"]},
+                "libloader.dylib": {"id": "old-loader", "deps": []},
+                "libexec.dylib": {"id": "old-exec", "deps": []},
+                "librpath.dylib": {"id": "old-rpath", "deps": []},
+                "libtransitive.dylib": {"id": "old-transitive", "deps": []},
+            }
+            fake = FakeMachO(metadata)
+            output = io.StringIO()
+            with patch.object(bundler, "command", fake), contextlib.redirect_stdout(output):
+                bundler.close_graph(files["app"], [search])
+            self.assertEqual(output.getvalue(), "bundled 5 libraries; signed 6 Mach-O files\n")
+            self.assertEqual(sorted(fake.signed), sorted(fake.verified))
+            self.assertEqual((stage / "librpath.dylib").read_bytes(), files["librpath.dylib"].read_bytes())
+            self.assertEqual((stage / "libtransitive.dylib").read_bytes(), files["libtransitive.dylib"].read_bytes())
+            for name in files:
+                if name != "app":
+                    self.assertTrue((stage / name).is_file())
+                    self.assertEqual(metadata[name]["id"], f"@loader_path/{name}")
+            self.assertTrue(all(dep.startswith("@loader_path/") or dep.startswith("/usr/lib/") for dep in metadata["app"]["deps"]))
+
+    def test_missing_ambiguous_search_and_basename_collision_fail(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            stage, one, two = root / "stage", root / "one", root / "two"
+            app = stage / "app"
+            self.touch(app)
+            with patch.object(bundler, "command", FakeMachO({"app": {"deps": ["@rpath/libmissing.dylib"]}})):
+                with self.assertRaisesRegex(bundler.BundleError, "missing"):
+                    bundler.close_graph(app, [])
+            for directory in (one, two):
+                self.touch(directory / "libsame.dylib")
+            fake = FakeMachO({"app": {"deps": ["@rpath/libsame.dylib"]}})
+            with patch.object(bundler, "command", fake):
+                with self.assertRaisesRegex(bundler.BundleError, "ambiguous"):
+                    bundler.close_graph(app, [one, two])
+            left, right = root / "left/libdup.dylib", root / "right/libdup.dylib"
+            self.touch(left)
+            self.touch(right)
+            fake = FakeMachO({"app": {"deps": [str(left), str(right)]}, "libdup.dylib": {"id": "old", "deps": []}})
+            with patch.object(bundler, "command", fake):
+                with self.assertRaisesRegex(bundler.BundleError, "basename collision"):
+                    bundler.close_graph(app, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/main/strumIntegration/demucsCppBootstrap.ts
+++ b/src/main/strumIntegration/demucsCppBootstrap.ts
@@ -27,7 +27,7 @@ import type { AutoChartProgressEvent } from './types'
 // v2: rebuilt with -march=x86-64-v3 (AVX2/FMA/BMI2) instead of
 //     -march=native so the binary runs on every x64 CPU without AVX-512
 //     (fixes illegal-instruction crash 0xC000001D on e.g. Ryzen Zen3).
-const DEMUCS_CPP_BIN_VERSION = '2'
+const DEMUCS_CPP_BIN_VERSION = '3'
 
 // htdemucs_6s ggml-f16 weights, hosted on HuggingFace by upstream
 // (sevagh/demucs.cpp). Pinned by SHA so a HuggingFace incident can't


### PR DESCRIPTION
## What

- close the staged macOS binary's complete non-system Mach-O dependency graph
- rewrite every bundled edge to `@loader_path`, normalize dylib IDs, and ad-hoc sign every modified Mach-O
- fail on missing, ambiguous, colliding, or non-closed dependencies instead of publishing a partially portable tarball
- bump the binary cache from v2 to v3 and run the binary workflow on `beta`, so clients do not reuse the broken v2 asset

## Why

The v1.0.19 arm64 `demucs_mt.cpp.main` asset links OpenBLAS through the build machine's absolute path:

```text
/opt/homebrew/opt/openblas/lib/libopenblas.0.dylib
```

On a Mac without that exact Homebrew prefix, dyld aborts before the CLI starts and OCTAVE falls back to Python Demucs.

Copying only OpenBLAS/libomp or adding an executable rpath does not close the bundle: OpenBLAS also loads gfortran, quadmath, and the GCC runtime. Rewriting those Mach-O files invalidates their existing signatures, so signing is part of the packaging fix.

## Proof

Revalidated on current `beta` at `ac15a6e70ae73b6a403900bc5ef33de0f055701d`:

- `uv run python -m py_compile scripts/bundle_macos_dylibs.py scripts/test_bundle_macos_dylibs.py`
- `uv run python -m unittest scripts.test_bundle_macos_dylibs` — 2 tests passed
- workflow YAML parsed successfully; all 13 bash-compatible `run` blocks passed `bash -n`
- `git diff --check`

Native macOS arm64 proof used the exact installed v1.0.19 executable (`sha256:e8b136d2e49d64c907f7846bc43752b44880da9b082e1a54a0dff5fabd84cb64`):

- before: exit 134 with `Library not loaded: /opt/homebrew/opt/openblas/lib/libopenblas.0.dylib`
- after: 5 dylibs bundled, 6 Mach-O files signed, 6/6 passed `codesign --verify --strict`
- the staged executable reaches its CLI usage path with no dyld error; `otool -L` shows `@loader_path/libopenblas.0.dylib`
- production-only revert of that load command restores exit 134 and the original dyld error; restoring it returns to the CLI usage path and 6/6 strict signature verification

The full cross-platform demucs.cpp build remains owned by the repository workflow; its release-producing path runs after a push to `beta`.

## AI assistance

This patch was prepared with OpenAI Codex assistance. I reproduced the defect against the released binary and validated the exact branch tree and native macOS behavior before opening this PR.
