### PR TITLE
fix: detect Visual Studio version for demucs.cpp Windows build

### DIFF
--- a/.github/workflows/demucs-cpp-binaries.yml
+++ b/.github/workflows/demucs-cpp-binaries.yml
@@ -203,13 +203,22 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path build | Out-Null
           cd build
-          # Use ClangCL toolset — ships with VS 2022 on windows-latest and
-          # accepts the GCC-style warning flags (-Wall, -Wextra, ...) that
-          # upstream's CMakeLists.txt adds unconditionally. MSVC's cl.exe
-          # rejects them.
+          # Pick the CMake generator that matches the Visual Studio actually
+          # installed on the runner. windows-latest migrated from VS 2022 to
+          # VS 2026, so a hard-coded generator breaks whenever the image
+          # rolls over.
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsMajor = ((& $vswhere -latest -products * -property installationVersion) -split '\.')[0]
+          $generator = @{ '17' = 'Visual Studio 17 2022'; '18' = 'Visual Studio 18 2026' }[$vsMajor]
+          if (-not $generator) { throw "No CMake generator mapping for Visual Studio major version '$vsMajor'" }
+          Write-Host "Using generator: $generator"
+          # Use ClangCL toolset — ships with Visual Studio on windows-latest
+          # and accepts the GCC-style warning flags (-Wall, -Wextra, ...)
+          # that upstream's CMakeLists.txt adds unconditionally. MSVC's
+          # cl.exe rejects them.
           # Pass /EHsc explicitly: ClangCL under MSBuild does not enable
           # C++ exceptions by default, but libnyquist uses try/throw.
-          cmake -G "Visual Studio 17 2022" -A x64 -T ClangCL `
+          cmake -G "$generator" -A x64 -T ClangCL `
             -DCMAKE_BUILD_TYPE=Release `
             -DCMAKE_CXX_FLAGS="/EHsc" `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_TOOLCHAIN" `


### PR DESCRIPTION
## Problem

The `Build demucs.cpp binaries` workflow keeps failing on the Windows job (e.g. [run 30377154367](https://github.com/opria123/octave/actions/runs/30377154367)):

```
CMake Error at CMakeLists.txt:24 (project):
  Generator
    Visual Studio 17 2022
  could not find any instance of Visual Studio.
```

`windows-latest` now resolves to the `windows-2025-vs2026` runner image, which ships **Visual Studio 2026 (v18)** and no longer includes VS 2022, so the hard-coded generator can't find anything. Linux and macOS jobs are unaffected.

## Fix

Query `vswhere` for the installed VS major version and map it to the matching CMake generator (`17` → `Visual Studio 17 2022`, `18` → `Visual Studio 18 2026`), failing loudly on anything unmapped. The image's CMake 4.4.0 supports the VS 2026 generator, and the ClangCL toolset components are installed there, so the rest of the configure step is unchanged.

## Validation

Triggered via `workflow_dispatch` on this branch (the workflow's documented test path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)