### PR TITLE
Release: merge beta into master (BRE lane markers, demucs macOS dylibs + Windows CI)

### DIFF
--- a/.github/workflows/demucs-cpp-binaries.yml
+++ b/.github/workflows/demucs-cpp-binaries.yml
@@ -203,13 +203,22 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path build | Out-Null
           cd build
-          # Use ClangCL toolset — ships with VS 2022 on windows-latest and
-          # accepts the GCC-style warning flags (-Wall, -Wextra, ...) that
-          # upstream's CMakeLists.txt adds unconditionally. MSVC's cl.exe
-          # rejects them.
+          # Pick the CMake generator that matches the Visual Studio actually
+          # installed on the runner. windows-latest migrated from VS 2022 to
+          # VS 2026, so a hard-coded generator breaks whenever the image
+          # rolls over.
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsMajor = ((& $vswhere -latest -products * -property installationVersion) -split '\.')[0]
+          $generator = @{ '17' = 'Visual Studio 17 2022'; '18' = 'Visual Studio 18 2026' }[$vsMajor]
+          if (-not $generator) { throw "No CMake generator mapping for Visual Studio major version '$vsMajor'" }
+          Write-Host "Using generator: $generator"
+          # Use ClangCL toolset — ships with Visual Studio on windows-latest
+          # and accepts the GCC-style warning flags (-Wall, -Wextra, ...)
+          # that upstream's CMakeLists.txt adds unconditionally. MSVC's
+          # cl.exe rejects them.
           # Pass /EHsc explicitly: ClangCL under MSBuild does not enable
           # C++ exceptions by default, but libnyquist uses try/throw.
-          cmake -G "Visual Studio 17 2022" -A x64 -T ClangCL `
+          cmake -G "$generator" -A x64 -T ClangCL `
             -DCMAKE_BUILD_TYPE=Release `
             -DCMAKE_CXX_FLAGS="/EHsc" `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_TOOLCHAIN" `

--- a/.github/workflows/demucs-cpp-binaries.yml
+++ b/.github/workflows/demucs-cpp-binaries.yml
@@ -20,13 +20,14 @@ on:
         required: false
         default: 'main'
   push:
-    branches: [master, main]
+    branches: [master, main, beta]
     paths:
       - '.github/workflows/demucs-cpp-binaries.yml'
       - 'src/main/strumIntegration/demucsCppBootstrap.ts'
+      - 'scripts/bundle_macos_dylibs.py'
 
 env:
-  BIN_VERSION: '2'
+  BIN_VERSION: '3'
   UPSTREAM_REPO: 'sevagh/demucs.cpp'
   UPSTREAM_REF: ${{ github.event.inputs.upstream_ref || 'main' }}
 
@@ -263,13 +264,11 @@ jobs:
               fi
             done
           elif [ "${{ matrix.platform }}" = "darwin" ]; then
-            # Copy libomp + openblas dylibs and rewrite RPATH to look in the
-            # tarball's own directory.
-            for dylib_dir in "$LIBOMP_PATH/lib" "$OPENBLAS_PATH/lib"; do
-              cp "$dylib_dir"/libomp*.dylib staged/ 2>/dev/null || true
-              cp "$dylib_dir"/libopenblas*.dylib staged/ 2>/dev/null || true
-            done
-            install_name_tool -add_rpath "@executable_path" "staged/${{ matrix.exe }}" || true
+            python3 scripts/test_bundle_macos_dylibs.py
+            python3 scripts/bundle_macos_dylibs.py "staged/${{ matrix.exe }}" \
+              --search "$OPENBLAS_PATH/lib" \
+              --search "$LIBOMP_PATH/lib" \
+              --search "$(brew --prefix gcc)/lib/gcc/current"
           fi
 
       - name: Create tarball
@@ -281,7 +280,7 @@ jobs:
           echo "ASSET=$ASSET" >> "$GITHUB_ENV"
 
       - name: Ensure release exists
-        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
@@ -295,7 +294,7 @@ jobs:
           fi
 
       - name: Upload to release
-        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash

--- a/scripts/bundle_macos_dylibs.py
+++ b/scripts/bundle_macos_dylibs.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Close, relocate, and ad-hoc-sign a staged macOS Mach-O dependency graph."""
+
+import argparse
+import re
+import shutil
+import subprocess
+from collections import deque
+from pathlib import Path
+
+SYSTEM_PREFIXES = ("/System/Library/", "/usr/lib/")
+
+
+class BundleError(RuntimeError):
+    pass
+
+
+def command(args, allow_failure=False):
+    result = subprocess.run(args, text=True, capture_output=True)
+    if result.returncode and not allow_failure:
+        detail = (result.stderr or result.stdout).strip()
+        raise BundleError(f"{' '.join(args)} failed ({result.returncode}): {detail}")
+    return result.stdout
+
+
+def dylib_id(path):
+    lines = command(["otool", "-D", str(path)], allow_failure=True).splitlines()[1:]
+    return next((line.strip() for line in lines if line.strip()), None)
+
+
+def dependencies(path):
+    own_id = dylib_id(path)
+    result = []
+    for line in command(["otool", "-L", str(path)]).splitlines()[1:]:
+        dependency = line.strip().split(" (", 1)[0]
+        if dependency and dependency != own_id:
+            result.append(dependency)
+    return result
+
+
+def rpaths(path):
+    lines = command(["otool", "-l", str(path)]).splitlines()
+    result = []
+    for index, line in enumerate(lines):
+        if line.strip() != "cmd LC_RPATH":
+            continue
+        for candidate in lines[index + 1:index + 5]:
+            match = re.match(r"\s*path (.+) \(offset \d+\)$", candidate)
+            if match:
+                result.append(match.group(1))
+                break
+    return result
+
+
+def expand(value, loader, executable):
+    for token, base in (("@loader_path", loader.parent), ("@executable_path", executable.parent)):
+        if value == token:
+            return base.resolve()
+        if value.startswith(token + "/"):
+            return (base / value[len(token) + 1:]).resolve()
+    return Path(value).resolve() if value.startswith("/") else None
+
+
+def unique_existing(paths):
+    return sorted({path.resolve() for path in paths if path.is_file()}, key=str)
+
+
+def resolve_dependency(dependency, loader, executable, loader_rpaths, searches):
+    if dependency.startswith(SYSTEM_PREFIXES):
+        return None
+    direct = []
+    if dependency.startswith("@rpath/"):
+        suffix = dependency[len("@rpath/"):]
+        for entry in loader_rpaths:
+            base = expand(entry, loader, executable)
+            if base is not None:
+                direct.append(base / suffix)
+    else:
+        resolved = expand(dependency, loader, executable)
+        direct.append(resolved if resolved is not None else loader.parent / dependency)
+    candidates = unique_existing(direct)
+    if not candidates:
+        candidates = unique_existing(directory / Path(dependency).name for directory in searches)
+    if len(candidates) != 1:
+        state = "missing" if not candidates else "ambiguous: " + ", ".join(map(str, candidates))
+        raise BundleError(f"cannot resolve {dependency} from {loader}: {state}")
+    return candidates[0]
+
+
+def close_graph(executable, searches):
+    executable = executable.resolve()
+    stage = executable.parent
+    if not executable.is_file():
+        raise BundleError(f"staged executable does not exist: {executable}")
+    for directory in searches:
+        if not directory.is_dir():
+            raise BundleError(f"search directory does not exist: {directory}")
+
+    queue = deque([(executable, executable)])
+    seen, changed, bundled = set(), set(), set()
+    owners = {executable.name: executable}
+    while queue:
+        origin, current = queue.popleft()
+        current = current.resolve()
+        if current in seen:
+            continue
+        seen.add(current)
+        current_rpaths = rpaths(origin)
+        for dependency in dependencies(origin):
+            source = resolve_dependency(dependency, origin, executable, current_rpaths, searches)
+            if source is None:
+                continue
+            name = Path(dependency).name
+            if not name or "/" in name:
+                raise BundleError(f"invalid dependency basename: {dependency}")
+            destination = stage / name
+            prior = owners.get(name)
+            source_real = source.resolve()
+            destination_real = destination.resolve() if destination.exists() else None
+            if prior is not None and source_real not in (prior, destination_real):
+                raise BundleError(f"basename collision for {name}: {prior} vs {source_real}")
+            if prior is None:
+                if destination.exists() and source_real != destination_real:
+                    raise BundleError(f"destination collision for {name}: {destination}")
+                owners[name] = source_real
+                if source_real != destination_real:
+                    shutil.copy2(source_real, destination)
+                command(["install_name_tool", "-id", f"@loader_path/{name}", str(destination)])
+                changed.add(destination.resolve())
+                bundled.add(destination.resolve())
+                queue.append((source_real, destination))
+            relocated = f"@loader_path/{name}"
+            if dependency != relocated:
+                command(["install_name_tool", "-change", dependency, relocated, str(current)])
+                changed.add(current)
+
+    for path in sorted(seen, key=str):
+        if path in bundled and dylib_id(path) != f"@loader_path/{path.name}":
+            raise BundleError(f"dylib ID was not normalized: {path}")
+        for dependency in dependencies(path):
+            if dependency.startswith(SYSTEM_PREFIXES):
+                continue
+            prefix = "@loader_path/"
+            name = dependency[len(prefix):] if dependency.startswith(prefix) else ""
+            if not name or "/" in name or not (stage / name).is_file():
+                raise BundleError(f"non-closed dependency in {path}: {dependency}")
+
+    for path in sorted(changed, key=str):
+        command(["codesign", "--force", "--sign", "-", "--timestamp=none", str(path)])
+    for path in sorted(changed, key=str):
+        command(["codesign", "--verify", "--strict", str(path)])
+    print(f"bundled {len(bundled)} libraries; signed {len(changed)} Mach-O files")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("executable", type=Path)
+    parser.add_argument("--search", action="append", default=[], type=Path)
+    args = parser.parse_args()
+    try:
+        close_graph(args.executable, [path.resolve() for path in args.search])
+    except (BundleError, OSError) as error:
+        parser.exit(1, f"error: {error}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_bundle_macos_dylibs.py
+++ b/scripts/test_bundle_macos_dylibs.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+import contextlib
+import importlib.util
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location("bundler", Path(__file__).with_name("bundle_macos_dylibs.py"))
+bundler = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bundler)
+
+
+class FakeMachO:
+    def __init__(self, metadata):
+        self.metadata = metadata
+        self.signed, self.verified = [], []
+
+    def __call__(self, args, allow_failure=False):
+        tool, *rest = args
+        if tool == "otool":
+            mode, path = rest
+            item = self.metadata[Path(path).name]
+            if mode == "-D":
+                return f"{path}:\n" + (f"{item['id']}\n" if item.get("id") else "")
+            if mode == "-L":
+                deps = ([item["id"]] if item.get("id") else []) + item.get("deps", [])
+                return f"{path}:\n" + "".join(f"\t{dep} (compatibility version 1.0.0)\n" for dep in deps)
+            if mode == "-l":
+                return "".join(f"cmd LC_RPATH\npath {entry} (offset 12)\n" for entry in item.get("rpaths", []))
+        if tool == "install_name_tool":
+            operation, old, *tail = rest
+            if operation == "-id":
+                self.metadata[Path(tail[0]).name]["id"] = old
+            else:
+                new, path = tail
+                item = self.metadata[Path(path).name]
+                item["deps"] = [new if dep == old else dep for dep in item.get("deps", [])]
+            return ""
+        if tool == "codesign":
+            path = Path(rest[-1]).name
+            if "--verify" in rest:
+                if path not in self.signed:
+                    raise bundler.BundleError(f"verified before signing: {path}")
+                self.verified.append(path)
+            else:
+                self.signed.append(path)
+            return ""
+        raise AssertionError(args)
+
+
+class BundleTests(unittest.TestCase):
+    def touch(self, path, content=None):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content or path.name.encode())
+
+    def test_recursive_graph_resolves_all_path_forms_and_signs(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            stage, source, search, rpath = root / "stage", root / "source", root / "search", root / "rpath"
+            files = {
+                "app": stage / "app",
+                "libabs.dylib": source / "libabs.dylib",
+                "libloader.dylib": stage / "nested/libloader.dylib",
+                "libexec.dylib": stage / "exec/libexec.dylib",
+                "librpath.dylib": rpath / "librpath.dylib",
+                "libtransitive.dylib": source / "libtransitive.dylib",
+            }
+            for path in files.values():
+                self.touch(path)
+            self.touch(search / "librpath.dylib", b"rpath-fallback-must-not-win")
+            self.touch(search / "libtransitive.dylib", b"loader-fallback-must-not-win")
+            metadata = {
+                "app": {"deps": [str(files["libabs.dylib"]), "@loader_path/nested/libloader.dylib", "@executable_path/exec/libexec.dylib", "@rpath/librpath.dylib", "/usr/lib/libSystem.B.dylib"], "rpaths": [str(rpath)]},
+                "libabs.dylib": {"id": str(files["libabs.dylib"]), "deps": ["@loader_path/libtransitive.dylib"]},
+                "libloader.dylib": {"id": "old-loader", "deps": []},
+                "libexec.dylib": {"id": "old-exec", "deps": []},
+                "librpath.dylib": {"id": "old-rpath", "deps": []},
+                "libtransitive.dylib": {"id": "old-transitive", "deps": []},
+            }
+            fake = FakeMachO(metadata)
+            output = io.StringIO()
+            with patch.object(bundler, "command", fake), contextlib.redirect_stdout(output):
+                bundler.close_graph(files["app"], [search])
+            self.assertEqual(output.getvalue(), "bundled 5 libraries; signed 6 Mach-O files\n")
+            self.assertEqual(sorted(fake.signed), sorted(fake.verified))
+            self.assertEqual((stage / "librpath.dylib").read_bytes(), files["librpath.dylib"].read_bytes())
+            self.assertEqual((stage / "libtransitive.dylib").read_bytes(), files["libtransitive.dylib"].read_bytes())
+            for name in files:
+                if name != "app":
+                    self.assertTrue((stage / name).is_file())
+                    self.assertEqual(metadata[name]["id"], f"@loader_path/{name}")
+            self.assertTrue(all(dep.startswith("@loader_path/") or dep.startswith("/usr/lib/") for dep in metadata["app"]["deps"]))
+
+    def test_missing_ambiguous_search_and_basename_collision_fail(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            stage, one, two = root / "stage", root / "one", root / "two"
+            app = stage / "app"
+            self.touch(app)
+            with patch.object(bundler, "command", FakeMachO({"app": {"deps": ["@rpath/libmissing.dylib"]}})):
+                with self.assertRaisesRegex(bundler.BundleError, "missing"):
+                    bundler.close_graph(app, [])
+            for directory in (one, two):
+                self.touch(directory / "libsame.dylib")
+            fake = FakeMachO({"app": {"deps": ["@rpath/libsame.dylib"]}})
+            with patch.object(bundler, "command", fake):
+                with self.assertRaisesRegex(bundler.BundleError, "ambiguous"):
+                    bundler.close_graph(app, [one, two])
+            left, right = root / "left/libdup.dylib", root / "right/libdup.dylib"
+            self.touch(left)
+            self.touch(right)
+            fake = FakeMachO({"app": {"deps": [str(left), str(right)]}, "libdup.dylib": {"id": "old", "deps": []}})
+            with patch.object(bundler, "command", fake):
+                with self.assertRaisesRegex(bundler.BundleError, "basename collision"):
+                    bundler.close_graph(app, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/main/strumIntegration/demucsCppBootstrap.ts
+++ b/src/main/strumIntegration/demucsCppBootstrap.ts
@@ -27,7 +27,7 @@ import type { AutoChartProgressEvent } from './types'
 // v2: rebuilt with -march=x86-64-v3 (AVX2/FMA/BMI2) instead of
 //     -march=native so the binary runs on every x64 CPU without AVX-512
 //     (fixes illegal-instruction crash 0xC000001D on e.g. Ryzen Zen3).
-const DEMUCS_CPP_BIN_VERSION = '2'
+const DEMUCS_CPP_BIN_VERSION = '3'
 
 // htdemucs_6s ggml-f16 weights, hosted on HuggingFace by upstream
 // (sevagh/demucs.cpp). Pinned by SHA so a HuggingFace incident can't

--- a/src/renderer/src/utils/midiParser.test.ts
+++ b/src/renderer/src/utils/midiParser.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { parseMidiBase64, serializeMidiBase64 } from './midiParser'
-import type { Note } from '../types'
+import { parseMidiBase64, serializeMidiBase64, parseChartFile, serializeChartFile } from './midiParser'
+import type { LaneMarker, Note } from '../types'
 
 // Issue #12: open frets and tap notes reverted to green/strums after a
 // save → reopen round-trip because serializeMidiBase64 dropped them.
@@ -58,5 +58,76 @@ describe('open fret / tap note MIDI round-trip', () => {
     )
     expect(twice.notes.find((n) => n.tick === 0)?.lane).toBe('open')
     expect(twice.notes.find((n) => n.tick === 480)?.flags?.isTap).toBe(true)
+  })
+})
+
+// Issue #37: BRE sections and drum rolls disappeared after a save → reopen
+// round-trip because both serializers dropped lane markers entirely.
+describe('lane marker round-trip', () => {
+  const tempo = [{ tick: 0, bpm: 120 }]
+  const timeSig = [{ tick: 0, numerator: 4, denominator: 4 }]
+  const mkNote = (over: Partial<Note>): Note => ({
+    id: 'x',
+    tick: 0,
+    duration: 120,
+    instrument: 'guitar',
+    difficulty: 'expert',
+    lane: 'green',
+    velocity: 100,
+    ...over
+  })
+  const mkMarker = (over: Partial<LaneMarker>): LaneMarker => ({
+    id: 'm',
+    tick: 960,
+    duration: 480,
+    instrument: 'drums',
+    type: 'drumRoll',
+    ...over
+  })
+  // The serializers only emit tracks that contain notes, so seed one per instrument.
+  const notes: Note[] = [
+    mkNote({ instrument: 'drums', lane: 'kick' }),
+    mkNote({ instrument: 'guitar', lane: 'green' })
+  ]
+
+  const findMarker = (
+    markers: LaneMarker[],
+    instrument: string,
+    type: string
+  ): LaneMarker | undefined =>
+    markers.find((m) => m.instrument === instrument && m.type === type)
+
+  it('preserves BRE and drum roll markers across MIDI serialize → parse', () => {
+    const markers: LaneMarker[] = [
+      mkMarker({ tick: 960, type: 'drumRoll' }),
+      mkMarker({ tick: 1920, type: 'bre' }),
+      mkMarker({ tick: 960, instrument: 'guitar', type: 'tremolo' }),
+      mkMarker({ tick: 1920, instrument: 'guitar', type: 'trill' }),
+      mkMarker({ tick: 2880, instrument: 'guitar', type: 'bre' })
+    ]
+    const parsed = parseMidiBase64(
+      serializeMidiBase64(notes, tempo, timeSig, 480, [], [], [], [], [], markers)
+    )
+
+    expect(findMarker(parsed.laneMarkers, 'drums', 'drumRoll')).toMatchObject({ tick: 960, duration: 480 })
+    expect(findMarker(parsed.laneMarkers, 'drums', 'bre')).toMatchObject({ tick: 1920, duration: 480 })
+    expect(findMarker(parsed.laneMarkers, 'guitar', 'tremolo')).toMatchObject({ tick: 960 })
+    expect(findMarker(parsed.laneMarkers, 'guitar', 'trill')).toMatchObject({ tick: 1920 })
+    expect(findMarker(parsed.laneMarkers, 'guitar', 'bre')).toMatchObject({ tick: 2880 })
+    // The BRE companion notes (121-124) must not leak into playable notes.
+    expect(parsed.notes).toHaveLength(notes.length)
+  })
+
+  it('preserves drum fill/roll markers across .chart serialize → parse', () => {
+    const markers: LaneMarker[] = [
+      mkMarker({ tick: 960, type: 'drumRoll' }),
+      mkMarker({ tick: 1920, type: 'bre' })
+    ]
+    const parsed = parseChartFile(
+      serializeChartFile(notes, tempo, timeSig, [], [], [], [], [], {}, 192, markers)
+    )
+
+    expect(findMarker(parsed.laneMarkers, 'drums', 'drumRoll')).toMatchObject({ tick: 960, duration: 480 })
+    expect(findMarker(parsed.laneMarkers, 'drums', 'bre')).toMatchObject({ tick: 1920, duration: 480 })
   })
 })

--- a/src/renderer/src/utils/midiParser.ts
+++ b/src/renderer/src/utils/midiParser.ts
@@ -481,11 +481,15 @@ export function parseMidiBase64(midiBase64: string): ParsedMidiData {
         continue
       }
 
-      // Lane markers
+      // Lane markers. RB/CH .mid convention: notes 120-124 mark a BRE / drum
+      // fill across all five lanes (120 carries the marker, 121-124 are its
+      // companions); on PART DRUMS 126/127 are single/double drum rolls while
+      // on other instruments 126 is tremolo and 127 is trill.
       let laneMarkerType: LaneMarkerType | null = null
-      if (noteNumber === 126) laneMarkerType = 'trill'
-      else if (noteNumber === 127) laneMarkerType = 'tremolo'
-      else if (noteNumber === 120 && (instrument === 'drums')) laneMarkerType = 'bre'
+      if (noteNumber === 126) laneMarkerType = instrument === 'drums' ? 'drumRoll' : 'tremolo'
+      else if (noteNumber === 127) laneMarkerType = instrument === 'drums' ? 'drumRoll' : 'trill'
+      else if (noteNumber === 120) laneMarkerType = 'bre'
+      else if (noteNumber >= 121 && noteNumber <= 124) continue // BRE companion lanes of 120
       else if (noteNumber === 103 && (instrument === 'drums')) laneMarkerType = 'discoFlip'
       else if (noteNumber === 65 && (instrument === 'drums')) laneMarkerType = 'drumRoll'
       if (laneMarkerType) {
@@ -1168,6 +1172,20 @@ export function parseChartFile(chartText: string): ParsedMidiData {
         continue
       }
 
+      // Drum lane markers: S 64 = fill/BRE, S 65 = drum roll, S 66 = double
+      // drum roll. Read from the expert section only — mirrors how they are
+      // written and avoids duplicates when charts repeat them per difficulty.
+      if (type === 'drums' && difficulty === 'expert') {
+        const specialMatch = line.match(/^\s*(\d+)\s*=\s*S\s+(6[456])\s+(\d+)/)
+        if (specialMatch) {
+          const tick = Math.round(parseInt(specialMatch[1], 10) * tickScale)
+          const duration = Math.round(parseInt(specialMatch[3], 10) * tickScale)
+          const markerType: LaneMarkerType = specialMatch[2] === '64' ? 'bre' : 'drumRoll'
+          laneMarkers.push({ id: uuidv4(), tick, duration, instrument, type: markerType })
+          continue
+        }
+      }
+
       // Solo: tick = E solo / tick = E soloend (some charts)
       // Also check for solo markers via S type (less common)
     }
@@ -1274,7 +1292,7 @@ export function serializeChartFile(
   songSections: SongSection[] = [],
   metadata: Record<string, unknown> = {},
   resolution = 192,
-  _laneMarkers: LaneMarker[] = [],
+  laneMarkers: LaneMarker[] = [],
   venueTrack: VenueTrackData = createEmptyVenueTrack()
 ): string {
   const tickScale = resolution / 480 // Convert from internal 480 PPQ to chart resolution
@@ -1421,6 +1439,18 @@ export function serializeChartFile(
         const duration = scaleTick(sp.duration)
         entries.push({ tick, text: `${tick} = S 2 ${duration}` })
       }
+      // Drum lane markers: .chart encodes a fill/BRE as S 64 and a drum roll
+      // as S 65. Trill/tremolo/disco flip have no .chart representation.
+      if (isDrums) {
+        for (const marker of laneMarkers) {
+          if (marker.instrument !== instrument) continue
+          const specialCode = marker.type === 'bre' ? 64 : marker.type === 'drumRoll' ? 65 : null
+          if (specialCode === null) continue
+          const tick = scaleTick(marker.tick)
+          const duration = scaleTick(marker.duration)
+          entries.push({ tick, text: `${tick} = S ${specialCode} ${duration}` })
+        }
+      }
     }
 
     // Sort by tick
@@ -1485,7 +1515,7 @@ export function serializeMidiBase64(
   vocalPhrases: VocalPhrase[] = [],
   soloSections: SoloSection[] = [],
   songSections: SongSection[] = [],
-  _laneMarkers: LaneMarker[] = [],
+  laneMarkers: LaneMarker[] = [],
   venueTrack: VenueTrackData = createEmptyVenueTrack()
 ): string {
   const midi = new Midi()
@@ -1605,6 +1635,22 @@ export function serializeMidiBase64(
             durationTicks: Math.max(solo.duration, 1),
             velocity: 1.0
           })
+        }
+      }
+      // Lane markers (see the parse-side mapping): BRE spans notes 120-124,
+      // drum rolls are 126 on PART DRUMS, tremolo/trill are 126/127 elsewhere.
+      // Disco flip has no note representation (it's a [mix N drums0d] text
+      // event) and is not serialized yet.
+      for (const marker of laneMarkers) {
+        if (marker.instrument !== instrumentName || marker.type === 'discoFlip') continue
+        const durationTicks = Math.max(marker.duration, 1)
+        if (marker.type === 'bre') {
+          for (let breNote = 120; breNote <= 124; breNote++) {
+            track.addNote({ midi: breNote, ticks: marker.tick, durationTicks, velocity: 1.0 })
+          }
+        } else {
+          const markerNote = marker.type === 'trill' && instrumentName !== 'drums' ? 127 : 126
+          track.addNote({ midi: markerNote, ticks: marker.tick, durationTicks, velocity: 1.0 })
         }
       }
     }


### PR DESCRIPTION
Cuts a stable release with everything validated on beta:

- **#38** — persist BRE and drum roll lane markers through save/load (the BRE fix, confirmed by reporter)
- **#39** — relocate bundled macOS demucs dylibs so stem separation works from the packaged app
- **#40** — detect the installed Visual Studio version in the demucs.cpp Windows build; fixes the CI failure caused by windows-latest migrating to the VS 2026 image

The demucs.cpp binaries workflow was validated end-to-end via workflow_dispatch (run 30398146943): all three platforms built and uploaded v3 binaries to the demucs-cpp-cache release.