### PR TITLE
Release: merge beta into master (Auto-Chart Star Power option)

### DIFF
--- a/resources/strum/strum_worker.py
+++ b/resources/strum/strum_worker.py
@@ -1983,6 +1983,45 @@ def _strip_pro_keys_tracks(midi_path: Path) -> int:
     return removed
 
 
+STAR_POWER_NOTE = 116
+
+
+def _strip_star_power_phrases(midi_path: Path) -> int:
+    """Remove every Star Power / Overdrive phrase (MIDI note 116) from the
+    instrument and vocal tracks of notes.mid in place. This honors the
+    user's `starPower=false` toggle (issue #42). Returns the number of
+    events removed."""
+    try:
+        import mido
+    except Exception:
+        return 0
+    mid = mido.MidiFile(str(midi_path))
+    removed = 0
+    for track in mid.tracks:
+        name = ""
+        for msg in track:
+            if msg.is_meta and msg.type == 'track_name':
+                name = str(getattr(msg, 'name', ''))
+                break
+        if not name.startswith("PART "):
+            continue
+        new_track = mido.MidiTrack()
+        carry = 0
+        for msg in track:
+            if msg.type in ('note_on', 'note_off') and getattr(msg, 'note', None) == STAR_POWER_NOTE:
+                removed += 1
+                carry += msg.time
+                continue
+            if carry:
+                msg = msg.copy(time=msg.time + carry)
+                carry = 0
+            new_track.append(msg)
+        track[:] = new_track
+    if removed > 0:
+        mid.save(str(midi_path))
+    return removed
+
+
 def _retime_midi_to_tempo_map(midi_path: Path, init_bpm: float, tempo_map: list[tuple[float, float]]) -> None:
     """Rewrite a STRUM-generated notes.mid (written with constant `init_bpm`)
     so it uses `tempo_map` while preserving each event's real-world time.
@@ -2807,6 +2846,10 @@ def run_pipeline(payload: dict[str, Any]) -> int:
     global INCLUDE_PRO_KEYS
     INCLUDE_PRO_KEYS = bool((enabled_tracks or {}).get('proKeys', True))
 
+    # Star Power generation toggle (community-requested, issue #42). On by
+    # default; when off, note-116 phrases are stripped from the finished chart.
+    generate_star_power = bool(payload.get("starPower", True))
+
     # Keep Demucs-separated stems as per-instrument oggs instead of discarding
     # them (community-requested). Off by default to preserve prior behaviour.
     global KEEP_STEMS
@@ -2954,6 +2997,19 @@ def run_pipeline(payload: dict[str, Any]) -> int:
                         )
                 except Exception as exc:
                     errors.append(f"{source.name}: pro-keys strip failed: {exc}")
+            if not generate_star_power and notes_mid.exists():
+                try:
+                    removed = _strip_star_power_phrases(notes_mid)
+                    if removed:
+                        emit_progress(
+                            run_id,
+                            "merge",
+                            f"Stripped {removed} Star Power phrase(s) from {notes_mid.name}",
+                            percent=min(96, source_start_percent + 65),
+                            current_item=source.name,
+                        )
+                except Exception as exc:
+                    errors.append(f"{source.name}: star-power strip failed: {exc}")
             if USER_TEMPO_MAP:
                 try:
                     if notes_mid.exists():

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -762,6 +762,7 @@ ipcMain.handle('strum:start', async (_event, options: {
   disableOnlineLookup?: boolean
   skipHarmonies?: boolean
   keepStems?: boolean
+  starPower?: boolean
   snapDrums?: boolean
   snapDrumsDivision?: number
   snapDrumsWindowMs?: number
@@ -794,6 +795,7 @@ ipcMain.handle('strum:start', async (_event, options: {
     disableOnlineLookup: options.disableOnlineLookup,
     skipHarmonies: options.skipHarmonies,
     keepStems: options.keepStems,
+    starPower: options.starPower,
     snapDrums: options.snapDrums,
     snapDrumsDivision: options.snapDrumsDivision,
     snapDrumsWindowMs: options.snapDrumsWindowMs,

--- a/src/main/strumIntegration/types.ts
+++ b/src/main/strumIntegration/types.ts
@@ -79,6 +79,12 @@ export interface AutoChartRunOptions {
    */
   keepStems?: boolean
   /**
+   * When false, Star Power / Overdrive phrases (MIDI note 116) are stripped
+   * from the generated chart so songs come out without any Star Power.
+   * Default true (generate Star Power as before).
+   */
+  starPower?: boolean
+  /**
    * When true, drum onsets that already land within `snapDrumsWindowMs` of a
    * 1/`snapDrumsDivision` grid line are snapped onto it, removing onset-timing
    * jitter (the "drums off by a 32nd note" complaint) while leaving genuinely

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -86,6 +86,7 @@ interface ChartEditorAPI {
     disableOnlineLookup?: boolean
     skipHarmonies?: boolean
     keepStems?: boolean
+    starPower?: boolean
     snapDrums?: boolean
     snapDrumsDivision?: number
     snapDrumsWindowMs?: number

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -166,6 +166,7 @@ const api = {
     disableOnlineLookup?: boolean
     skipHarmonies?: boolean
     keepStems?: boolean
+    starPower?: boolean
     snapDrums?: boolean
     snapDrumsDivision?: number
     snapDrumsWindowMs?: number

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -56,6 +56,7 @@ export function Toolbar(): React.JSX.Element {
     autoChartDisableOnlineLookup,
     autoChartDownloadVideo,
     autoChartKeepStems,
+    autoChartStarPower,
     autoChartImproveTempo,
     autoChartSnapDrums,
     autoChartEnabledTracks,
@@ -656,6 +657,7 @@ export function Toolbar(): React.JSX.Element {
         disableOnlineLookup: autoChartDisableOnlineLookup,
         skipHarmonies: !autoChartEnabledTracks.harmonies,
         keepStems: autoChartKeepStems,
+        starPower: autoChartStarPower,
         autoTempo: autoChartImproveTempo,
         snapDrums: autoChartSnapDrums,
         enabledTracks: autoChartEnabledTracks,
@@ -689,6 +691,7 @@ export function Toolbar(): React.JSX.Element {
     autoChartFolders,
     autoChartImproveTempo,
     autoChartKeepStems,
+    autoChartStarPower,
     autoChartSnapDrums,
     autoChartStemFolders,
     autoChartStemSongs,
@@ -1985,6 +1988,24 @@ export function Toolbar(): React.JSX.Element {
                               Export the separated stems (drums, bass, vocals, etc.) as
                               per-instrument oggs in each song folder instead of discarding them.
                               Lets you remix or mute instruments in-game.
+                            </small>
+                          </span>
+                        </label>
+
+                        <label className="settings-checkbox-row">
+                          <input
+                            type="checkbox"
+                            checked={autoChartStarPower}
+                            onChange={(event) =>
+                              updateSettings({ autoChartStarPower: event.target.checked })
+                            }
+                            disabled={autoChartProgress.isRunning}
+                          />
+                          <span>
+                            Generate Star Power phrases
+                            <small style={{ display: 'block', opacity: 0.7 }}>
+                              Uncheck to create charts without any Star Power / Overdrive
+                              phrases. You can always add your own later in the editor.
                             </small>
                           </span>
                         </label>

--- a/src/renderer/src/stores/projectStore.test.ts
+++ b/src/renderer/src/stores/projectStore.test.ts
@@ -25,6 +25,7 @@ describe('Auto-Chart settings', () => {
       autoChartDisableOnlineLookup: true,
       autoChartDownloadVideo: false,
       autoChartKeepStems: true,
+      autoChartStarPower: false,
       autoChartImproveTempo: false,
       autoChartSnapDrums: true,
       autoChartEnabledTracks: {
@@ -42,6 +43,7 @@ describe('Auto-Chart settings', () => {
       autoChartDisableOnlineLookup: true,
       autoChartDownloadVideo: false,
       autoChartKeepStems: true,
+      autoChartStarPower: false,
       autoChartImproveTempo: false,
       autoChartSnapDrums: true,
       autoChartEnabledTracks: {
@@ -60,6 +62,7 @@ describe('Auto-Chart settings', () => {
       autoChartDisableOnlineLookup: true,
       autoChartDownloadVideo: false,
       autoChartKeepStems: true,
+      autoChartStarPower: false,
       autoChartImproveTempo: false,
       autoChartSnapDrums: true,
       autoChartEnabledTracks: {

--- a/src/renderer/src/stores/projectStore.ts
+++ b/src/renderer/src/stores/projectStore.ts
@@ -81,6 +81,7 @@ const defaultSettings: AppSettings = {
   autoChartDisableOnlineLookup: false,
   autoChartDownloadVideo: true,
   autoChartKeepStems: false,
+  autoChartStarPower: true,
   autoChartImproveTempo: true,
   autoChartSnapDrums: false,
   autoChartEnabledTracks: {

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -288,6 +288,7 @@ export interface AppSettings {
   autoChartDisableOnlineLookup: boolean
   autoChartDownloadVideo: boolean
   autoChartKeepStems: boolean
+  autoChartStarPower: boolean // Generate Star Power phrases in auto-charted songs (issue #42)
   autoChartImproveTempo: boolean
   autoChartSnapDrums: boolean
   autoChartEnabledTracks: AutoChartEnabledTracks


### PR DESCRIPTION
Cuts a stable release with what's been validated on beta since v-last:

- **#42** — new **Generate Star Power phrases** option in the Auto-Chart Advanced settings (default on, matching previous behavior). When unchecked, the worker strips all Star Power / Overdrive phrases (MIDI note 116) from the generated charts while preserving event timing (PR #43).

Validated on beta: full test suite (75/75), production build, a standalone MIDI-strip harness (timing preserved, vocal phrase markers untouched, idempotent), and a Playwright check of the built app confirming the option renders and persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)