### PR TITLE
fix: stop song titles starting with a digit from crashing the app

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,6 +29,7 @@ import {
   type SongMetadataSearchRequest,
   type SongMetadataSearchResult
 } from '../shared/songMetadata'
+import { parseIniFile, serializeIniFile } from '../shared/iniFile'
 import { createApplicationMenuTemplate } from './applicationMenu'
 
 // Point fluent-ffmpeg at the bundled static binary
@@ -1471,48 +1472,6 @@ ipcMain.handle('song:readAudio', async (_event, songPath: string) => {
 
   return results.length > 0 ? results : null
 })
-
-// Parse INI file content
-function parseIniFile(content: string): Record<string, string | number> {
-  const result: Record<string, string | number> = {}
-  const lines = content.split(/\r?\n/)
-  let inSongSection = false
-
-  for (const line of lines) {
-    const trimmed = line.trim()
-
-    // Section header
-    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
-      inSongSection = trimmed.toLowerCase() === '[song]'
-      continue
-    }
-
-    // Key-value pair
-    if (inSongSection && trimmed.includes('=')) {
-      const [key, ...valueParts] = trimmed.split('=')
-      const value = valueParts.join('=').trim()
-
-      // Try to parse as number
-      const numValue = parseFloat(value)
-      result[key.trim()] = isNaN(numValue) ? value : numValue
-    }
-  }
-
-  return result
-}
-
-// Serialize metadata to INI format
-function serializeIniFile(metadata: Record<string, unknown>): string {
-  const lines = ['[song]']
-
-  for (const [key, value] of Object.entries(metadata)) {
-    if (value !== undefined && value !== null && value !== '') {
-      lines.push(`${key} = ${value}`)
-    }
-  }
-
-  return lines.join('\n')
-}
 
 // ============================================
 // Video Import IPC Handlers

--- a/src/renderer/src/components/ProjectExplorer.tsx
+++ b/src/renderer/src/components/ProjectExplorer.tsx
@@ -28,6 +28,13 @@ interface SongEntry {
   hasKeys: boolean
 }
 
+// song.ini values arrive as `string | number` — a title such as "1979" is
+// legitimately parsed as a number. Everything downstream treats metadata as
+// text, so coerce at the boundary rather than casting and hoping.
+function iniText(value: string | number | undefined): string {
+  return value === undefined || value === null ? '' : String(value)
+}
+
 function isCurrentLibrarySong(songId: string, folderPath: string, loadVersion: number): boolean {
   const project = useProjectStore.getState()
   return (
@@ -251,12 +258,12 @@ export function ProjectExplorer(): React.JSX.Element {
               addedAt: songFolder.addedAt,
               metadata: {
                 ...(iniData ?? {}),
-                name: (iniData?.name as string) || (iniData?.title as string) || songFolder.name,
-                artist: (iniData?.artist as string) || 'Unknown Artist',
-                album: iniData?.album as string,
-                genre: iniData?.genre as string,
+                name: iniText(iniData?.name) || iniText(iniData?.title) || songFolder.name,
+                artist: iniText(iniData?.artist) || 'Unknown Artist',
+                album: iniText(iniData?.album) || undefined,
+                genre: iniText(iniData?.genre) || undefined,
                 year: iniData?.year !== undefined ? String(iniData.year) : undefined,
-                charter: iniData?.charter as string,
+                charter: iniText(iniData?.charter) || undefined,
                 song_length: iniData?.song_length as number,
                 preview_start_time: iniData?.preview_start_time as number
               }

--- a/src/renderer/src/utils/libraryOrganization.test.ts
+++ b/src/renderer/src/utils/libraryOrganization.test.ts
@@ -69,4 +69,22 @@ describe('organizeLibrarySongs', () => {
       'Unknown Year'
     ])
   })
+
+  // A numeric title in song.ini, or a stale library cache written before that
+  // was fixed, must never be able to take the whole app down.
+  it('tolerates non-string metadata without throwing', () => {
+    const poisoned = [
+      { id: '1', name: 1979 as unknown as string, artist: 99 as unknown as string, year: 1979 as unknown as string },
+      { id: '2', name: 'Apple', artist: 'Alpha', year: '2020' }
+    ]
+
+    for (const group of ['none', 'title-initial', 'artist', 'year'] as const) {
+      expect(() => organizeLibrarySongs(poisoned, '', 'title', group)).not.toThrow()
+      expect(() => organizeLibrarySongs(poisoned, '19', 'artist', group)).not.toThrow()
+    }
+
+    expect(
+      organizeLibrarySongs(poisoned, '', 'title', 'title-initial').map((g) => g.label)
+    ).toEqual(['#', 'A'])
+  })
 })

--- a/src/renderer/src/utils/libraryOrganization.ts
+++ b/src/renderer/src/utils/libraryOrganization.ts
@@ -22,13 +22,21 @@ export interface LibrarySongGroup<T extends LibrarySongSummary> {
 
 const collator = new Intl.Collator('en', { numeric: true, sensitivity: 'base' })
 
-function initialGroup(value: string): string {
-  const first = value.trim().charAt(0).toLocaleUpperCase()
+// Song metadata originates in song.ini and in the on-disk library cache, so a
+// numeric title ("1979") or a stale cache entry can hand us a non-string here.
+// Grouping the library must never be able to take the whole app down.
+function text(value: unknown): string {
+  if (typeof value === 'string') return value
+  return value === undefined || value === null ? '' : String(value)
+}
+
+function initialGroup(value: unknown): string {
+  const first = text(value).trim().charAt(0).toLocaleUpperCase()
   return /^[A-Z]$/.test(first) ? first : '#'
 }
 
-function numericYear(year?: string): number | null {
-  const match = year?.match(/\d{4}/)
+function numericYear(year?: unknown): number | null {
+  const match = text(year).match(/\d{4}/)
   return match ? Number(match[0]) : null
 }
 
@@ -38,24 +46,27 @@ export function organizeLibrarySongs<T extends LibrarySongSummary>(
   sort: LibrarySort,
   group: LibraryGroup
 ): LibrarySongGroup<T>[] {
-  const normalizedQuery = query.trim().toLowerCase()
+  const normalizedQuery = text(query).trim().toLowerCase()
   const filtered = normalizedQuery
     ? songs.filter(({ name, artist }) =>
-        `${name}\n${artist}`.toLowerCase().includes(normalizedQuery)
+        `${text(name)}\n${text(artist)}`.toLowerCase().includes(normalizedQuery)
       )
     : songs
 
   const sorted = [...filtered].sort((left, right) => {
     let primary = 0
-    if (sort === 'artist') primary = collator.compare(left.artist, right.artist)
+    if (sort === 'artist') primary = collator.compare(text(left.artist), text(right.artist))
     else if (sort === 'added-newest') primary = (right.addedAt ?? -Infinity) - (left.addedAt ?? -Infinity)
     else if (sort === 'added-oldest') primary = (left.addedAt ?? Infinity) - (right.addedAt ?? Infinity)
     else if (sort === 'year-newest') primary = (numericYear(right.year) ?? -Infinity) - (numericYear(left.year) ?? -Infinity)
     else if (sort === 'year-oldest') primary = (numericYear(left.year) ?? Infinity) - (numericYear(right.year) ?? Infinity)
-    else primary = collator.compare(left.name, right.name)
+    else primary = collator.compare(text(left.name), text(right.name))
     if (primary !== 0) return primary
-    const secondary = sort === 'artist' ? collator.compare(left.name, right.name) : collator.compare(left.artist, right.artist)
-    return secondary || collator.compare(left.id, right.id)
+    const secondary =
+      sort === 'artist'
+        ? collator.compare(text(left.name), text(right.name))
+        : collator.compare(text(left.artist), text(right.artist))
+    return secondary || collator.compare(text(left.id), text(right.id))
   })
 
   if (group === 'none') return [{ label: '', songs: sorted }]
@@ -64,7 +75,7 @@ export function organizeLibrarySongs<T extends LibrarySongSummary>(
   for (const song of sorted) {
     const label =
       group === 'artist'
-        ? song.artist.trim() || 'Unknown Artist'
+        ? text(song.artist).trim() || 'Unknown Artist'
         : group === 'year'
           ? String(numericYear(song.year) ?? 'Unknown Year')
           : initialGroup(song.name)

--- a/src/shared/iniFile.test.ts
+++ b/src/shared/iniFile.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { parseIniFile, serializeIniFile } from './iniFile'
+
+describe('parseIniFile', () => {
+  it('keeps titles that merely start with digits as strings', () => {
+    // Regression: parseFloat("99 Problems") is 99, so these titles used to be
+    // handed to the renderer as numbers and crashed the library view.
+    const parsed = parseIniFile(
+      ['[song]', 'name = 99 Problems', 'artist = 2 Live Crew', 'album = 3 Feet High'].join('\n')
+    )
+
+    expect(parsed.name).toBe('99 Problems')
+    expect(parsed.artist).toBe('2 Live Crew')
+    expect(parsed.album).toBe('3 Feet High')
+  })
+
+  it('still parses fully numeric values as numbers', () => {
+    const parsed = parseIniFile(
+      ['[song]', 'song_length = 257400', 'delay = -1200', 'preview_start_time = 30.5'].join('\n')
+    )
+
+    expect(parsed.song_length).toBe(257400)
+    expect(parsed.delay).toBe(-1200)
+    expect(parsed.preview_start_time).toBe(30.5)
+  })
+
+  it('reads values containing "=" and ignores keys outside [song]', () => {
+    const parsed = parseIniFile(
+      ['[other]', 'name = Ignored', '[song]', 'name = a=b', 'charter = STRUM'].join('\r\n')
+    )
+
+    expect(parsed.name).toBe('a=b')
+    expect(parsed.charter).toBe('STRUM')
+  })
+})
+
+describe('serializeIniFile', () => {
+  it('round-trips a digit-leading title', () => {
+    const ini = serializeIniFile({ name: '99 Problems', song_length: 257400, album: '' })
+
+    expect(parseIniFile(ini).name).toBe('99 Problems')
+    expect(parseIniFile(ini).song_length).toBe(257400)
+    expect(ini).not.toContain('album')
+  })
+})

--- a/src/shared/iniFile.ts
+++ b/src/shared/iniFile.ts
@@ -1,0 +1,48 @@
+// song.ini reading/writing. Kept out of the main entry point so the parsing
+// rules can be unit tested without booting Electron.
+
+// Only a value that is numeric in its entirety becomes a number. `parseFloat`
+// is deliberately avoided here: it happily reads a leading number out of a
+// title like "99 Problems" (-> 99) or "7 Nation Army" (-> 7), which then flows
+// through the app as a number where a string is expected.
+const NUMERIC_VALUE = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/
+
+// Parse INI file content
+export function parseIniFile(content: string): Record<string, string | number> {
+  const result: Record<string, string | number> = {}
+  const lines = content.split(/\r?\n/)
+  let inSongSection = false
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+
+    // Section header
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+      inSongSection = trimmed.toLowerCase() === '[song]'
+      continue
+    }
+
+    // Key-value pair
+    if (inSongSection && trimmed.includes('=')) {
+      const [key, ...valueParts] = trimmed.split('=')
+      const value = valueParts.join('=').trim()
+
+      result[key.trim()] = NUMERIC_VALUE.test(value) ? Number(value) : value
+    }
+  }
+
+  return result
+}
+
+// Serialize metadata to INI format
+export function serializeIniFile(metadata: Record<string, unknown>): string {
+  const lines = ['[song]']
+
+  for (const [key, value] of Object.entries(metadata)) {
+    if (value !== undefined && value !== null && value !== '') {
+      lines.push(`${key} = ${value}`)
+    }
+  }
+
+  return lines.join('\n')
+}


### PR DESCRIPTION
## The bug

Reported in #48: after auto-charting, OCTAVE replaces its whole UI with **"Something went wrong / value.trim is not a function"**, and then does it again on every launch.

## Root cause

`parseIniFile` used `parseFloat` to decide whether a `song.ini` value was a number:

```js
const numValue = parseFloat(value)
result[key.trim()] = isNaN(numValue) ? value : numValue
```

`parseFloat` reads a *leading* number out of any string, so `name = 99 Problems` became the number `99` and `7 Nation Army` became `7`. That number reached the renderer via `ProjectExplorer`, which only **cast** it (`iniData?.name as string`) instead of coercing it, and landed in `initialGroup(value)` → `value.trim()`. The TypeError is thrown during render, so the error boundary in `App.tsx` swallows the entire UI.

Two things make it as severe as reported:

- The default library grouping is `'title-initial'`, so `initialGroup` runs on **every** library render.
- The bad value is written into the on-disk library cache, which is applied *before* the fresh folder scan — so once you hit it, the app crashes on every launch, and a fresh install pointed at the same music does it again.

Confirmed three ways: the shipped `out/renderer` bundle is unminified (electron-vite default), which is why the identifier `value` survived into the message; the whole bundle has only three `value.trim(` call sites and `initialGroup` is the only one reachable from a render; and running the pre-fix code on `name = 99 Problems` reproduces the message verbatim.

## The fix

Each layer was independently wrong, so all three are fixed:

- **`src/shared/iniFile.ts` (new)** — parser extracted out of `main/index.ts` so it is testable without booting Electron, and it now coerces to a number only when the value is numeric *in its entirety*. `song_length = 257400` stays a number; `99 Problems` stays a string.
- **`ProjectExplorer.tsx`** — the `as string` casts become a real `iniText()` coercion, because a title like `1979` is still legitimately parsed as a number and must not reach the UI as one.
- **`libraryOrganization.ts`** — sorting and grouping no longer throw on non-string metadata. This is what lets already-affected users recover on next launch instead of deleting their cache by hand. `numericYear` had the same latent crash on a numeric year.

## Testing

- New `src/shared/iniFile.test.ts`: digit-leading titles stay strings, fully numeric values stay numbers, `=` in values and non-`[song]` sections still handled, serialize/parse round-trip.
- New case in `libraryOrganization.test.ts`: poisoned non-string metadata across all four grouping modes doesn't throw.
- Full suite passes (80 tests / 14 files), `npm run typecheck` clean, ESLint reports 0 errors on changed files.

Addresses #48 — deliberately *not* "Fixes", so the issue stays open for the reporter to verify on the beta build before we close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
