### PR TITLE
release: v1.0.25 — Generate from Expert

### DIFF
--- a/docs/guide/midi-editor.md
+++ b/docs/guide/midi-editor.md
@@ -39,7 +39,29 @@ See the [Keyboard Shortcuts reference](/reference/keyboard-shortcuts) for the fu
 
 The difficulty tabs above the lanes let you author Expert / Hard / Medium / Easy independently. The active difficulty is what's edited and displayed in the [Chart Preview](/guide/chart-preview).
 
-> **Tip:** Use *Generate from Expert* in the toolbar overflow to bootstrap lower difficulties from your Expert chart, then tweak.
+Songs produced by [Auto-Chart](/guide/auto-chart) already arrive with all four difficulties filled in. For charts you wrote by hand, or imported with only an Expert track, use **Generate from Expert**.
+
+> **Note:** Copy / paste keeps each note on the difficulty it was copied from. Pasting Expert notes while a lower difficulty tab is active adds them back to Expert, not to the tab you're viewing.
+
+### Generate from Expert
+
+The **Generate from Expert** button in the piano-roll toolbar derives Hard / Medium / Easy from your Expert chart, using the same reduction rules Auto-Chart applies. Tick the instruments and the difficulties you want, then hit Generate.
+
+It covers drums, guitar, bass, keys, Pro Keys and Pro Guitar / Bass. Vocals are absent because CH / RB have no per-difficulty vocal charts. An instrument with no Expert notes is skipped rather than blanked.
+
+What the rules do, broadly:
+
+| Instrument | Hard | Medium | Easy |
+|------------|------|--------|------|
+| Drums | Drops ghost notes and very fast repeats, thins busy hi-hat | Kick to a basic pulse (no double kick), hi-hat halved, toms only on accents | Kick and snare only, very sparse |
+| Guitar / Bass | Thins dense runs, caps frets at blue, no taps | No 3-note chords, thins harder, strum-only | Single notes, capped at yellow, sparsest |
+| Keys / Pro Keys | Drops every 4th note | Every other note, voicings cut to two | Every 3rd note, one voice per onset |
+| Pro Guitar / Bass | Voicings capped at four strings | Capped at two strings | Single low string per onset — frets are never transposed |
+
+Two things worth knowing before you run it:
+
+- **It replaces, it doesn't merge.** Any hand-authored work on the difficulties you tick is discarded for the instruments you tick. The popover tells you how many notes that is before you commit, and `Ctrl/Cmd+Z` puts them back in one step.
+- **Reduction is gap-based, so slow songs reduce less.** The thresholds are in milliseconds, not beats. On a sparse or slow chart, Hard can come out identical to Expert simply because no passage is dense enough to thin. Treat the output as a starting point to tweak, not a finished chart.
 
 ## Copy / paste & undo
 
@@ -59,4 +81,6 @@ The difficulty tabs above the lanes let you author Expert / Hard / Medium / Easy
 
 ## Lane swap
 
-For 5-fret instruments, the **Swap Lanes** popover (toolbar overflow) mirrors the chart left-to-right — useful when adapting a chart to a southpaw layout.
+The **Swap Lanes** button in the piano-roll toolbar opens a popover where you pick an instrument and two of its lanes, then swap every note between them. It covers guitar / bass / keys (open, green, red, yellow, blue, orange), drums (kick, snare, and the tom / cymbal variants) and Pro Guitar / Pro Bass strings 1–6; Pro Keys and vocals aren't supported.
+
+The **All difficulties** checkbox is ticked by default, so the swap applies to every difficulty. Untick it to limit the swap to the difficulty you're currently editing.

--- a/src/renderer/src/components/MidiEditor.css
+++ b/src/renderer/src/components/MidiEditor.css
@@ -565,6 +565,38 @@
   accent-color: var(--accent-color);
 }
 
+/* Generate from Expert popover — reuses the swap popover shell, adds grouping
+   labels and the overwrite warning. */
+.midi-generate-popover {
+  max-height: 70vh;
+  overflow-y: auto;
+  gap: 6px;
+}
+
+.midi-generate-section-label {
+  margin-top: 6px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.midi-generate-section-label:first-child {
+  margin-top: 0;
+}
+
+.midi-generate-warning {
+  margin-top: 4px;
+  padding: 8px;
+  border-radius: 6px;
+  background: rgba(255, 176, 32, 0.12);
+  border: 1px solid rgba(255, 176, 32, 0.4);
+  color: var(--text-primary);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
 .midi-swap-popover-actions {
   display: flex;
   gap: 6px;

--- a/src/renderer/src/components/MidiEditor.tsx
+++ b/src/renderer/src/components/MidiEditor.tsx
@@ -3,6 +3,11 @@ import { useRef, useEffect, useLayoutEffect, useState, useCallback, useMemo } fr
 import { useProjectStore, getSongStore, useSettingsStore, useUIStore } from '../stores'
 import type { Note, NoteFlags, NoteModifiers, Instrument, DrumLane, GuitarLane, Difficulty, EditingTool, StarPowerPhrase, SoloSection, LaneMarker, LaneMarkerType, VocalNote, VocalPhrase, HarmonyPart,TempoEvent } from '../types'
 import { PRO_KEYS_MIN, PRO_KEYS_MAX, SUSTAIN_THRESHOLD_MID, SUSTAIN_THRESHOLD_CHART } from '../types'
+import {
+  DERIVED_DIFFICULTIES,
+  REDUCIBLE_INSTRUMENTS,
+  type DerivedDifficulty
+} from '../utils/difficultyReduction'
 import { getAudioDuration, getAudioSources, onAudioLoaded, playPitchPreview, stopPitchPreview } from '../services/audioService'
 import { buildTickAlignedWaveformPeaks } from '../services/waveformService'
 import './MidiEditor.css'
@@ -2324,6 +2329,62 @@ function SnapSelector({
   )
 }
 
+// Where a toolbar popover is pinned. Popovers use fixed positioning so the
+// toolbar's own scrolling can't clip them.
+interface PopoverAnchor {
+  left: number
+  top?: number
+  bottom?: number
+}
+
+/**
+ * Toolbar popover plumbing: open state, and an anchor that keeps the popover
+ * on screen. The piano-roll toolbar sits at the bottom of the window, so a
+ * popover opening downward gets cut off — after it renders we measure it and
+ * flip it above the button when it would overflow. Measuring beats estimating
+ * from the content, which silently breaks as soon as the popover grows.
+ */
+function useToolbarPopover(): {
+  open: boolean
+  setOpen: (open: boolean) => void
+  toggle: () => void
+  anchor: PopoverAnchor | null
+  buttonRef: React.RefObject<HTMLButtonElement | null>
+  popoverRef: React.RefObject<HTMLDivElement | null>
+} {
+  const [open, setOpen] = useState(false)
+  const [anchor, setAnchor] = useState<PopoverAnchor | null>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+
+  const toggle = (): void => {
+    if (open) {
+      setOpen(false)
+      return
+    }
+    const rect = buttonRef.current?.getBoundingClientRect()
+    // Open downward first; the layout effect below flips it if that clips.
+    if (rect) setAnchor({ left: rect.left, top: rect.bottom + 4 })
+    setOpen(true)
+  }
+
+  useLayoutEffect(() => {
+    if (!open || !popoverRef.current || !buttonRef.current) return
+    const rect = buttonRef.current.getBoundingClientRect()
+    const clipped = rect.bottom + 4 + popoverRef.current.offsetHeight > window.innerHeight
+    setAnchor((prev) => {
+      if (!prev) return prev
+      // Already in the right place — returning prev keeps this from looping.
+      if (clipped === (prev.bottom !== undefined)) return prev
+      return clipped
+        ? { left: rect.left, bottom: window.innerHeight - rect.top + 4 }
+        : { left: rect.left, top: rect.bottom + 4 }
+    })
+  })
+
+  return { open, setOpen, toggle, anchor, buttonRef, popoverRef }
+}
+
 // Per-instrument lane sets used by the Swap Lanes tool.
 const SWAP_LANE_OPTIONS: Record<Instrument, string[]> = {
   guitar: ['open', 'green', 'red', 'yellow', 'blue', 'orange'],
@@ -2347,9 +2408,7 @@ function SwapLanesTool({
   activeDifficulty: Difficulty
   defaultInstrument: Instrument
 }): React.JSX.Element {
-  const [open, setOpen] = useState(false)
-  const [popoverPos, setPopoverPos] = useState<{ top: number; left: number } | null>(null)
-  const buttonRef = useRef<HTMLButtonElement>(null)
+  const { open, setOpen, toggle: togglePopover, anchor, buttonRef, popoverRef } = useToolbarPopover()
   const [instrument, setInstrument] = useState<Instrument>(
     SWAP_LANE_OPTIONS[defaultInstrument].length > 0 ? defaultInstrument : 'guitar'
   )
@@ -2366,16 +2425,6 @@ function SwapLanesTool({
     if (!next.includes(laneB)) setLaneB(next[2] ?? next[0] ?? '')
   }, [instrument, laneA, laneB])
 
-  const togglePopover = (): void => {
-    if (open) {
-      setOpen(false)
-      return
-    }
-    const rect = buttonRef.current?.getBoundingClientRect()
-    if (rect) setPopoverPos({ top: rect.bottom + 4, left: rect.left })
-    setOpen(true)
-  }
-
   return (
     <div className="midi-swap-tool" style={{ position: 'relative' }}>
       <button
@@ -2387,15 +2436,11 @@ function SwapLanesTool({
         <span>↔</span>
         <span>Swap Lanes</span>
       </button>
-      {open && popoverPos && (
+      {open && anchor && (
         <div
+          ref={popoverRef}
           className="midi-swap-popover"
-          style={{
-            position: 'fixed',
-            top: popoverPos.top,
-            left: popoverPos.left,
-            zIndex: 1000
-          }}
+          style={{ position: 'fixed', ...anchor, zIndex: 1000 }}
         >
           <label className="midi-swap-popover-row">
             <span>Instrument</span>
@@ -2451,6 +2496,150 @@ function SwapLanesTool({
               }}
             >
               Swap
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const INSTRUMENT_LABELS: Partial<Record<Instrument, string>> = {
+  drums: 'Drums',
+  guitar: 'Guitar',
+  bass: 'Bass',
+  keys: 'Keys',
+  proKeys: 'Pro Keys',
+  proGuitar: 'Pro Guitar',
+  proBass: 'Pro Bass'
+}
+
+const DIFFICULTY_LABELS: Record<DerivedDifficulty, string> = {
+  hard: 'Hard',
+  medium: 'Medium',
+  easy: 'Easy'
+}
+
+// Generate from Expert — derive lower difficulties using the same reduction
+// rules STRUM applies during Auto-Chart. Destructive for the difficulties it
+// writes, so the popover names exactly what will be overwritten before running.
+function GenerateFromExpertTool({
+  notes,
+  onGenerate
+}: {
+  notes: Note[]
+  onGenerate: (instruments: Instrument[], targets: DerivedDifficulty[]) => void
+}): React.JSX.Element {
+  const { open, setOpen, toggle: togglePopover, anchor, buttonRef, popoverRef } = useToolbarPopover()
+
+  // Only instruments that actually have an Expert chart can be reduced.
+  const available = useMemo(
+    () =>
+      REDUCIBLE_INSTRUMENTS.filter((i) =>
+        notes.some((n) => n.instrument === i && n.difficulty === 'expert')
+      ),
+    [notes]
+  )
+
+  const [selectedInstruments, setSelectedInstruments] = useState<Set<Instrument>>(new Set())
+  const [selectedTargets, setSelectedTargets] = useState<Set<DerivedDifficulty>>(
+    new Set(DERIVED_DIFFICULTIES)
+  )
+
+  // Default to every instrument that has an Expert chart, refreshed whenever the
+  // set changes underneath us (import, auto-chart, or charting a new instrument).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSelectedInstruments(new Set(available))
+  }, [available])
+
+  // Notes that this run would destroy — existing work on the targeted pairs.
+  const overwriteCount = useMemo(
+    () =>
+      notes.filter(
+        (n) =>
+          selectedInstruments.has(n.instrument) &&
+          n.difficulty !== 'expert' &&
+          selectedTargets.has(n.difficulty as DerivedDifficulty)
+      ).length,
+    [notes, selectedInstruments, selectedTargets]
+  )
+
+  const toggle = <T,>(set: Set<T>, value: T): Set<T> => {
+    const next = new Set(set)
+    if (next.has(value)) next.delete(value)
+    else next.add(value)
+    return next
+  }
+
+  const canRun = selectedInstruments.size > 0 && selectedTargets.size > 0
+
+  return (
+    <div className="midi-generate-tool" style={{ position: 'relative' }}>
+      <button
+        ref={buttonRef}
+        className="edit-tool-button"
+        onClick={togglePopover}
+        disabled={available.length === 0}
+        title={
+          available.length === 0
+            ? 'Chart something on Expert first — lower difficulties are derived from it'
+            : 'Derive Hard / Medium / Easy from the Expert chart'
+        }
+      >
+        <span>⇩</span>
+        <span>Generate from Expert</span>
+      </button>
+      {open && anchor && (
+        <div
+          ref={popoverRef}
+          className="midi-swap-popover midi-generate-popover"
+          style={{ position: 'fixed', ...anchor, zIndex: 1000 }}
+        >
+          <div className="midi-generate-section-label">Instruments</div>
+          {available.map((instrument) => (
+            <label key={instrument} className="midi-swap-popover-checkbox">
+              <input
+                type="checkbox"
+                checked={selectedInstruments.has(instrument)}
+                onChange={() =>
+                  setSelectedInstruments((s) => toggle(s, instrument))
+                }
+              />
+              <span>{INSTRUMENT_LABELS[instrument] ?? instrument}</span>
+            </label>
+          ))}
+
+          <div className="midi-generate-section-label">Difficulties to write</div>
+          {DERIVED_DIFFICULTIES.map((difficulty) => (
+            <label key={difficulty} className="midi-swap-popover-checkbox">
+              <input
+                type="checkbox"
+                checked={selectedTargets.has(difficulty)}
+                onChange={() => setSelectedTargets((s) => toggle(s, difficulty))}
+              />
+              <span>{DIFFICULTY_LABELS[difficulty]}</span>
+            </label>
+          ))}
+
+          {overwriteCount > 0 && (
+            <div className="midi-generate-warning">
+              Replaces {overwriteCount} existing note{overwriteCount === 1 ? '' : 's'} on the
+              selected difficulties. Undo (Ctrl+Z) restores them.
+            </div>
+          )}
+
+          <div className="midi-swap-popover-actions">
+            <button onClick={() => setOpen(false)}>Cancel</button>
+            <button
+              className="primary"
+              disabled={!canRun}
+              onClick={() => {
+                onGenerate([...selectedInstruments], [...selectedTargets])
+                setOpen(false)
+              }}
+            >
+              Generate
             </button>
           </div>
         </div>
@@ -3824,6 +4013,12 @@ export function MidiEditor(): React.JSX.Element {
           defaultInstrument={Array.from(visibleInstruments)[0] ?? 'guitar'}
           onSwap={(instrument, laneA, laneB, scope) =>
             songStore?.getState().swapLanes(instrument, laneA, laneB, scope)
+          }
+        />
+        <GenerateFromExpertTool
+          notes={notes}
+          onGenerate={(instruments, targets) =>
+            songStore?.getState().generateFromExpert({ instruments, targets })
           }
         />
         <div className="midi-zoom-controls">

--- a/src/renderer/src/stores/songStore.ts
+++ b/src/renderer/src/stores/songStore.ts
@@ -7,6 +7,11 @@ import {
   snapEntriesToGrid,
   SNAP_TO_GRID_TOLERANCE_FRACTION
 } from '../utils/snapToGrid'
+import {
+  generateFromExpert as reduceFromExpert,
+  type GenerateFromExpertOptions,
+  type GenerateFromExpertResult
+} from '../utils/difficultyReduction'
 import type {
   SongData,
   SongEditorState,
@@ -28,6 +33,9 @@ import type {
   SongSection
 } from '../types'
 
+/** What `generateFromExpert` produced, minus the notes themselves (already applied). */
+export type GenerateFromExpertSummary = Omit<GenerateFromExpertResult, 'notes'>
+
 // Song store state interface
 interface SongStoreState extends SongEditorState {
   // Clipboard (not in undo history)
@@ -41,6 +49,7 @@ interface SongStoreState extends SongEditorState {
   deleteSelectedNotes: () => void
   swapLanes: (instrument: Instrument, laneA: string, laneB: string, difficulty?: Difficulty | 'all') => void
   snapNotesToGrid: (division?: number, toleranceTicks?: number) => void
+  generateFromExpert: (options?: GenerateFromExpertOptions) => GenerateFromExpertSummary
 
   // Selection actions
   selectNote: (noteId: string, addToSelection?: boolean) => void
@@ -198,7 +207,7 @@ const createDefaultEditorState = (song: SongData): SongEditorState => ({
 })
 
 // Store creator function
-const createSongStoreSlice: StateCreator<SongStoreState> = (set) => {
+const createSongStoreSlice: StateCreator<SongStoreState> = (set, get) => {
   const defaultSong = createDefaultSong('default', '')
   const defaultState = createDefaultEditorState(defaultSong)
 
@@ -271,6 +280,31 @@ const createSongStoreSlice: StateCreator<SongStoreState> = (set) => {
           isDirty: true
         }
       }),
+
+    // Derive Hard / Medium / Easy from the Expert chart, replacing whatever was
+    // on those difficulties for the instruments involved. The reduction rules
+    // are a port of the ones STRUM runs during Auto-Chart (see
+    // utils/difficultyReduction.ts) so a hand-authored chart ends up with the
+    // same shape of lower difficulties an auto-charted one gets.
+    //
+    // Destructive by design: callers must confirm with the user first, because
+    // any hand-tweaked Hard/Medium/Easy work for the targeted instruments is
+    // discarded. It lands as one entry in the undo history, so Ctrl+Z restores
+    // the previous difficulties in full.
+    generateFromExpert: (options = {}) => {
+      const state = get()
+      const result = reduceFromExpert(state.song.notes, state.song.tempoEvents, options)
+      const { notes, ...summary } = result
+
+      set({
+        song: { ...state.song, notes },
+        // Selected ids may point at notes that were just replaced.
+        selectedNoteIds: [],
+        isDirty: true
+      })
+
+      return summary
+    },
 
     // Snap notes to the nearest grid line for the given division (defaults to the
     // active snap division). When notes are selected, only those are snapped;

--- a/src/renderer/src/utils/difficultyReduction.test.ts
+++ b/src/renderer/src/utils/difficultyReduction.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect } from 'vitest'
+import { generateFromExpert, DERIVED_DIFFICULTIES } from './difficultyReduction'
+import type { Note, TempoEvent, DrumLane, GuitarLane, ProGuitarString } from '../types'
+
+// 120 BPM: 1 beat = 500ms, 480 ticks per beat, so 1 tick ≈ 1.0417ms.
+const TEMPO: TempoEvent[] = [{ tick: 0, bpm: 120 }]
+
+let seq = 0
+const mkNote = (over: Partial<Note>): Note => ({
+  id: `n${seq++}`,
+  tick: 0,
+  duration: 0,
+  instrument: 'drums',
+  difficulty: 'expert',
+  lane: 'snare',
+  velocity: 100,
+  ...over
+})
+
+/** A run of notes spaced `step` ticks apart. */
+const run = (count: number, step: number, over: Partial<Note> = {}): Note[] =>
+  Array.from({ length: count }, (_, i) => mkNote({ ...over, tick: i * step }))
+
+const at = (notes: Note[], instrument: string, difficulty: string): Note[] =>
+  notes.filter((n) => n.instrument === instrument && n.difficulty === difficulty)
+
+describe('generateFromExpert', () => {
+  describe('general behaviour', () => {
+    it('leaves the expert chart untouched', () => {
+      const expert = run(16, 120, { instrument: 'guitar', lane: 'green', duration: 60 })
+      const { notes } = generateFromExpert(expert, TEMPO)
+
+      const expertOut = at(notes, 'guitar', 'expert')
+      expect(expertOut).toHaveLength(16)
+      expect(expertOut.map((n) => n.tick)).toEqual(expert.map((n) => n.tick))
+    })
+
+    it('produces monotonically sparser charts down the difficulties', () => {
+      const expert = run(64, 120, { instrument: 'guitar', lane: 'green', duration: 60 })
+      const { notes } = generateFromExpert(expert, TEMPO)
+
+      const hard = at(notes, 'guitar', 'hard').length
+      const medium = at(notes, 'guitar', 'medium').length
+      const easy = at(notes, 'guitar', 'easy').length
+
+      expect(hard).toBeLessThan(64)
+      expect(medium).toBeLessThanOrEqual(hard)
+      expect(easy).toBeLessThanOrEqual(medium)
+      expect(easy).toBeGreaterThan(0)
+    })
+
+    it('is deterministic — re-running yields the same ticks and lanes', () => {
+      const expert = run(40, 90, { instrument: 'guitar', lane: 'red', duration: 45 })
+      const first = generateFromExpert(expert, TEMPO).notes
+      const second = generateFromExpert(expert, TEMPO).notes
+
+      const shape = (ns: Note[]): string =>
+        ns
+          .filter((n) => n.difficulty !== 'expert')
+          .map((n) => `${n.difficulty}:${n.tick}:${n.lane}:${n.duration}`)
+          .sort()
+          .join('|')
+
+      expect(shape(first)).toBe(shape(second))
+    })
+
+    it('replaces existing lower difficulties rather than stacking onto them', () => {
+      const expert = run(16, 120, { instrument: 'guitar', lane: 'green' })
+      const staleHard = run(3, 480, { instrument: 'guitar', lane: 'orange', difficulty: 'hard' })
+      const { notes } = generateFromExpert([...expert, ...staleHard], TEMPO)
+
+      const hard = at(notes, 'guitar', 'hard')
+      expect(hard.some((n) => n.lane === 'orange')).toBe(false)
+    })
+
+    it('assigns fresh ids so generated notes are independent of their source', () => {
+      const expert = run(8, 240, { instrument: 'guitar', lane: 'green' })
+      const { notes } = generateFromExpert(expert, TEMPO)
+
+      const ids = notes.map((n) => n.id)
+      expect(new Set(ids).size).toBe(ids.length)
+    })
+
+    it('skips an instrument with no expert notes and leaves its other difficulties alone', () => {
+      const orphanHard = run(4, 240, { instrument: 'bass', lane: 'green', difficulty: 'hard' })
+      const { notes, skipped } = generateFromExpert(orphanHard, TEMPO)
+
+      expect(skipped).toContain('bass')
+      expect(at(notes, 'bass', 'hard')).toHaveLength(4)
+    })
+
+    it('only touches the instruments and targets it was asked for', () => {
+      const guitar = run(16, 120, { instrument: 'guitar', lane: 'green' })
+      const drums = run(16, 120, { instrument: 'drums', lane: 'snare' })
+      const { notes } = generateFromExpert([...guitar, ...drums], TEMPO, {
+        instruments: ['guitar'],
+        targets: ['hard']
+      })
+
+      expect(at(notes, 'guitar', 'hard').length).toBeGreaterThan(0)
+      expect(at(notes, 'guitar', 'medium')).toHaveLength(0)
+      expect(at(notes, 'drums', 'hard')).toHaveLength(0)
+    })
+
+    it('reports what it generated per instrument and difficulty', () => {
+      const drums = run(24, 240, { instrument: 'drums', lane: 'snare' })
+      const { generated } = generateFromExpert(drums, TEMPO, { instruments: ['drums'] })
+
+      expect(Object.keys(generated)).toEqual(['drums'])
+      for (const d of DERIVED_DIFFICULTIES) {
+        expect(generated.drums[d]).toBeGreaterThan(0)
+      }
+    })
+  })
+
+  describe('drums', () => {
+    it('drops ghost notes on hard', () => {
+      // Well-spaced so only the ghost rule can remove anything.
+      const expert = [
+        mkNote({ tick: 0, lane: 'snare' }),
+        mkNote({ tick: 480, lane: 'snare', flags: { isGhost: true } }),
+        mkNote({ tick: 960, lane: 'snare', velocity: 40 }),
+        mkNote({ tick: 1440, lane: 'snare' })
+      ]
+      const { notes } = generateFromExpert(expert, TEMPO, { targets: ['hard'] })
+
+      expect(at(notes, 'drums', 'hard').map((n) => n.tick)).toEqual([0, 1440])
+    })
+
+    it('removes double kick by medium', () => {
+      const expert = [
+        mkNote({ tick: 0, lane: 'kick' }),
+        mkNote({ tick: 480, lane: 'kick', flags: { isDoubleKick: true } }),
+        mkNote({ tick: 960, lane: 'kick' })
+      ]
+      const { notes } = generateFromExpert(expert, TEMPO, { targets: ['medium'] })
+
+      const medium = at(notes, 'drums', 'medium')
+      expect(medium.every((n) => !n.flags?.isDoubleKick)).toBe(true)
+      expect(medium.map((n) => n.tick)).not.toContain(480)
+    })
+
+    it('leaves easy with kick and snare only, folding cymbals away', () => {
+      const lanes: DrumLane[] = [
+        'kick',
+        'snare',
+        'yellowCymbal',
+        'blueTom',
+        'greenCymbal',
+        'kick',
+        'snare'
+      ]
+      const expert = lanes.map((lane, i) => mkNote({ tick: i * 480, lane, velocity: 110 }))
+      const { notes } = generateFromExpert(expert, TEMPO, { targets: ['easy'] })
+
+      const easy = at(notes, 'drums', 'easy')
+      expect(easy.length).toBeGreaterThan(0)
+      expect(easy.every((n) => n.lane === 'kick' || n.lane === 'snare')).toBe(true)
+      expect(easy.every((n) => !n.flags?.isCymbal)).toBe(true)
+    })
+
+    it('thins a fast hi-hat pattern on hard', () => {
+      // 16ths at 120 BPM = 125ms apart, inside the 150ms "fast pattern" window.
+      const expert = run(12, 120, { lane: 'yellowCymbal', velocity: 100 })
+      const { notes } = generateFromExpert(expert, TEMPO, { targets: ['hard'] })
+
+      expect(at(notes, 'drums', 'hard').length).toBeLessThan(12)
+    })
+  })
+
+  describe('guitar and bass', () => {
+    it('caps frets at blue on hard and yellow on easy', () => {
+      const lanes: GuitarLane[] = ['green', 'red', 'yellow', 'blue', 'orange']
+      // Spaced a beat apart so nothing is thinned away before the cap is checked.
+      const expert = lanes.map((lane, i) =>
+        mkNote({ tick: i * 480, lane, instrument: 'guitar', duration: 0 })
+      )
+      const { notes } = generateFromExpert(expert, TEMPO)
+
+      const laneOf = (d: string): string[] => at(notes, 'guitar', d).map((n) => String(n.lane))
+      expect(laneOf('hard')).not.toContain('orange')
+      expect(laneOf('easy')).not.toContain('orange')
+      expect(laneOf('easy')).not.toContain('blue')
+    })
+
+    it('reduces chords to single notes on easy', () => {
+      const chord = [
+        mkNote({ tick: 0, lane: 'green', instrument: 'guitar' }),
+        mkNote({ tick: 0, lane: 'red', instrument: 'guitar' }),
+        mkNote({ tick: 0, lane: 'yellow', instrument: 'guitar' })
+      ]
+      const { notes } = generateFromExpert(chord, TEMPO, { targets: ['easy'] })
+
+      expect(at(notes, 'guitar', 'easy')).toHaveLength(1)
+    })
+
+    it('never emits a forbidden green+orange two-note chord on hard', () => {
+      const chord = [
+        mkNote({ tick: 0, lane: 'green', instrument: 'guitar' }),
+        mkNote({ tick: 0, lane: 'orange', instrument: 'guitar' })
+      ]
+      const { notes } = generateFromExpert(chord, TEMPO, { targets: ['hard'] })
+
+      const lanes = at(notes, 'guitar', 'hard').map((n) => n.lane)
+      expect(lanes.includes('green') && lanes.includes('orange')).toBe(false)
+    })
+
+    it('preserves open notes instead of remapping them to a fret', () => {
+      const expert = [
+        mkNote({ tick: 0, lane: 'open', instrument: 'bass' }),
+        mkNote({ tick: 960, lane: 'open', instrument: 'bass' }),
+        mkNote({ tick: 1920, lane: 'open', instrument: 'bass' })
+      ]
+      const { notes } = generateFromExpert(expert, TEMPO, { targets: ['hard'] })
+
+      const hard = at(notes, 'bass', 'hard')
+      expect(hard.length).toBeGreaterThan(0)
+      expect(hard.every((n) => n.lane === 'open')).toBe(true)
+    })
+
+    it('thins bass more gently than guitar', () => {
+      const guitar = run(48, 120, { instrument: 'guitar', lane: 'green' })
+      const bass = run(48, 120, { instrument: 'bass', lane: 'green' })
+      const { notes } = generateFromExpert([...guitar, ...bass], TEMPO, { targets: ['hard'] })
+
+      expect(at(notes, 'bass', 'hard').length).toBeGreaterThan(at(notes, 'guitar', 'hard').length)
+    })
+
+    it('strips taps everywhere and hopos below hard', () => {
+      const expert = run(12, 480, {
+        instrument: 'guitar',
+        lane: 'green',
+        flags: { isHOPO: true, isTap: true }
+      })
+      const { notes } = generateFromExpert(expert, TEMPO)
+
+      expect(at(notes, 'guitar', 'hard').every((n) => !n.flags?.isTap)).toBe(true)
+      expect(at(notes, 'guitar', 'medium').every((n) => !n.flags?.isHOPO)).toBe(true)
+      expect(at(notes, 'guitar', 'easy').every((n) => !n.flags?.isHOPO)).toBe(true)
+    })
+
+    it('never lets a sustain run into the next note', () => {
+      // Overlapping sustains: each note is 2 beats long but only 1 beat apart.
+      const expert = run(8, 480, { instrument: 'guitar', lane: 'green', duration: 960 })
+      const { notes } = generateFromExpert(expert, TEMPO, { targets: ['hard'] })
+
+      const hard = at(notes, 'guitar', 'hard').sort((a, b) => a.tick - b.tick)
+      for (let i = 0; i < hard.length - 1; i++) {
+        expect(hard[i].tick + hard[i].duration).toBeLessThan(hard[i + 1].tick)
+      }
+    })
+  })
+
+  describe('keys and pro keys', () => {
+    it('thins keys and shrinks chord voicings on the way down', () => {
+      const chords = Array.from({ length: 12 }, (_, i) => [
+        mkNote({ tick: i * 480, lane: 'green', instrument: 'keys' }),
+        mkNote({ tick: i * 480, lane: 'red', instrument: 'keys' }),
+        mkNote({ tick: i * 480, lane: 'yellow', instrument: 'keys' })
+      ]).flat()
+      const { notes } = generateFromExpert(chords, TEMPO, { instruments: ['keys'] })
+
+      const perTick = (d: string): number[] => {
+        const counts = new Map<number, number>()
+        for (const n of at(notes, 'keys', d)) counts.set(n.tick, (counts.get(n.tick) ?? 0) + 1)
+        return [...counts.values()]
+      }
+
+      expect(perTick('medium').every((c) => c <= 2)).toBe(true)
+      expect(perTick('easy').every((c) => c === 1)).toBe(true)
+    })
+
+    it('keeps pro keys pitches intact rather than remapping them', () => {
+      const expert = run(24, 240, { instrument: 'proKeys', lane: 60 })
+      const { notes } = generateFromExpert(expert, TEMPO, { instruments: ['proKeys'] })
+
+      const derived = notes.filter((n) => n.instrument === 'proKeys' && n.difficulty !== 'expert')
+      expect(derived.length).toBeGreaterThan(0)
+      expect(derived.every((n) => n.lane === 60)).toBe(true)
+    })
+
+    it('leaves pro keys easy as a single voice per onset', () => {
+      const voicings = Array.from({ length: 9 }, (_, i) => [
+        mkNote({ tick: i * 480, lane: 48, instrument: 'proKeys' }),
+        mkNote({ tick: i * 480, lane: 55, instrument: 'proKeys' }),
+        mkNote({ tick: i * 480, lane: 64, instrument: 'proKeys' })
+      ]).flat()
+      const { notes } = generateFromExpert(voicings, TEMPO, {
+        instruments: ['proKeys'],
+        targets: ['easy']
+      })
+
+      const counts = new Map<number, number>()
+      for (const n of at(notes, 'proKeys', 'easy')) counts.set(n.tick, (counts.get(n.tick) ?? 0) + 1)
+      expect([...counts.values()].every((c) => c === 1)).toBe(true)
+    })
+  })
+
+  describe('pro guitar and pro bass', () => {
+    it('never transposes a fret', () => {
+      const expert = run(16, 240, { instrument: 'proGuitar', lane: 0, string: 5, fret: 12 })
+      const { notes } = generateFromExpert(expert, TEMPO, { instruments: ['proGuitar'] })
+
+      const derived = notes.filter((n) => n.instrument === 'proGuitar' && n.difficulty !== 'expert')
+      expect(derived.length).toBeGreaterThan(0)
+      expect(derived.every((n) => n.fret === 12 && n.string === 5)).toBe(true)
+    })
+
+    it('shrinks voicings to a single low string on easy', () => {
+      const voicings = Array.from({ length: 9 }, (_, i) =>
+        ([6, 5, 4, 3] as ProGuitarString[]).map((string) =>
+          mkNote({ tick: i * 480, lane: 0, instrument: 'proGuitar', string, fret: 3 })
+        )
+      ).flat()
+      const { notes } = generateFromExpert(voicings, TEMPO, {
+        instruments: ['proGuitar'],
+        targets: ['easy']
+      })
+
+      const easy = at(notes, 'proGuitar', 'easy')
+      const counts = new Map<number, number>()
+      for (const n of easy) counts.set(n.tick, (counts.get(n.tick) ?? 0) + 1)
+      expect([...counts.values()].every((c) => c === 1)).toBe(true)
+      expect(easy.every((n) => n.string === 6)).toBe(true)
+    })
+
+    it('caps hard voicings at four strings', () => {
+      const voicings = Array.from({ length: 6 }, (_, i) =>
+        ([6, 5, 4, 3, 2, 1] as ProGuitarString[]).map((string) =>
+          mkNote({ tick: i * 960, lane: 0, instrument: 'proBass', string, fret: 5 })
+        )
+      ).flat()
+      const { notes } = generateFromExpert(voicings, TEMPO, {
+        instruments: ['proBass'],
+        targets: ['hard']
+      })
+
+      const counts = new Map<number, number>()
+      for (const n of at(notes, 'proBass', 'hard')) counts.set(n.tick, (counts.get(n.tick) ?? 0) + 1)
+      expect([...counts.values()].every((c) => c <= 4)).toBe(true)
+    })
+  })
+
+  describe('tempo handling', () => {
+    it('applies ms-based rules against the tempo map, not a fixed bpm', () => {
+      // Identical tick spacing, different tempo: 240 ticks is 150ms at 200 BPM
+      // (a fast passage, thinned hardest) but 500ms at 60 BPM (a moderate one).
+      const fast = generateFromExpert(run(32, 240, { instrument: 'guitar', lane: 'green' }), [
+        { tick: 0, bpm: 200 }
+      ])
+      const slow = generateFromExpert(run(32, 240, { instrument: 'guitar', lane: 'green' }), [
+        { tick: 0, bpm: 60 }
+      ])
+
+      const fastEasy = fast.notes.filter(
+        (n) => n.instrument === 'guitar' && n.difficulty === 'easy'
+      ).length
+      const slowEasy = slow.notes.filter(
+        (n) => n.instrument === 'guitar' && n.difficulty === 'easy'
+      ).length
+
+      // Slower tempo = wider real-world gaps = less thinning.
+      expect(slowEasy).toBeGreaterThan(fastEasy)
+    })
+  })
+})

--- a/src/renderer/src/utils/difficultyReduction.ts
+++ b/src/renderer/src/utils/difficultyReduction.ts
@@ -1,0 +1,681 @@
+// Difficulty reduction — derive Hard / Medium / Easy from an Expert chart.
+//
+// These rules are a TypeScript port of the reducers STRUM already runs during
+// Auto-Chart (strum: src/export/midi.py `_reduce_to_hard/_medium/_easy`,
+// src/inference/guitar_bass.py `reduce_to_difficulty`, src/inference/c3_rules.py,
+// and the keys / pro-keys stride reduction in scripts/batch_pipeline.py). They
+// live here rather than behind an IPC call into the Python worker so that
+// reduction works on hand-authored and imported charts without bootstrapping
+// the Auto-Chart runtime, runs instantly, and folds into a single undo entry.
+//
+// Everything in this file is pure: same input notes + tempo map → same output,
+// no randomness, no clock. That keeps generated difficulties reproducible, so
+// re-running on an unchanged Expert chart is a no-op rather than a reshuffle.
+import { v4 as uuidv4 } from 'uuid'
+import { tickToMs } from './chartValidation'
+import type {
+  Note,
+  Difficulty,
+  DrumLane,
+  GuitarLane,
+  Instrument,
+  TempoEvent,
+  ProGuitarString
+} from '../types'
+
+/** Difficulties this module can derive. Expert is the source, never a target. */
+export type DerivedDifficulty = Exclude<Difficulty, 'expert'>
+
+export const DERIVED_DIFFICULTIES: DerivedDifficulty[] = ['hard', 'medium', 'easy']
+
+/**
+ * Instruments reduction understands. Vocals are absent on purpose: CH/RB have
+ * no per-difficulty vocal charts, and OCTAVE stores vocals in a separate
+ * `vocalNotes` array anyway.
+ */
+export const REDUCIBLE_INSTRUMENTS: Instrument[] = [
+  'drums',
+  'guitar',
+  'bass',
+  'keys',
+  'proKeys',
+  'proGuitar',
+  'proBass'
+]
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
+/** A note paired with its wall-clock position, so ms-based rules can be applied. */
+interface TimedNote {
+  note: Note
+  ms: number
+  endMs: number
+}
+
+function withTimes(notes: Note[], tempoEvents: TempoEvent[]): TimedNote[] {
+  return notes
+    .map((note) => ({
+      note,
+      ms: tickToMs(note.tick, tempoEvents),
+      endMs: tickToMs(note.tick + note.duration, tempoEvents)
+    }))
+    .sort((a, b) => a.ms - b.ms || String(a.note.lane).localeCompare(String(b.note.lane)))
+}
+
+/**
+ * Local tempo at a tick, used by the C3 sustain/gap rules. STRUM works from a
+ * single global BPM; charts in the editor can have a full tempo map, so we take
+ * the tempo in force at each note instead of assuming one.
+ */
+function bpmAt(tick: number, tempoEvents: TempoEvent[]): number {
+  if (tempoEvents.length === 0) return 120
+  let bpm = tempoEvents[0].bpm
+  for (const ev of tempoEvents) {
+    if (ev.tick > tick) break
+    bpm = ev.bpm
+  }
+  return bpm > 0 ? bpm : 120
+}
+
+/** Rebuild a note at a target difficulty. New id — difficulties are independent rows. */
+function derive(note: Note, difficulty: DerivedDifficulty, overrides: Partial<Note> = {}): Note {
+  return {
+    ...note,
+    ...overrides,
+    id: uuidv4(),
+    difficulty
+  }
+}
+
+/** Group notes that share an onset tick — a chord in the editor's model. */
+function groupByTick(timed: TimedNote[]): TimedNote[][] {
+  const groups: TimedNote[][] = []
+  for (const item of timed) {
+    const last = groups[groups.length - 1]
+    if (last && last[0].note.tick === item.note.tick) last.push(item)
+    else groups.push([item])
+  }
+  return groups
+}
+
+// ─── Drums ───────────────────────────────────────────────────────────────────
+
+// STRUM reduces on lane indices 0-4 (kick / snare / hi-hat / blue / green).
+// OCTAVE names its lanes and splits tom vs cymbal, so map into STRUM's space to
+// keep the thresholds meaning the same thing.
+const DRUM_LANE_INDEX: Record<DrumLane, number> = {
+  kick: 0,
+  snare: 1,
+  yellowTom: 2,
+  yellowCymbal: 2,
+  blueTom: 3,
+  blueCymbal: 3,
+  greenTom: 4,
+  greenCymbal: 4
+}
+
+/** Cymbal lanes collapse to their tom counterpart when Easy drops cymbals. */
+const CYMBAL_TO_TOM: Partial<Record<DrumLane, DrumLane>> = {
+  yellowCymbal: 'yellowTom',
+  blueCymbal: 'blueTom',
+  greenCymbal: 'greenTom'
+}
+
+function laneIndexOf(note: Note): number {
+  return DRUM_LANE_INDEX[note.lane as DrumLane] ?? 1
+}
+
+/**
+ * Hard (~75% of Expert): drop ghost notes, drop very fast repeats on a lane,
+ * thin dense hi-hat. Mirrors strum `_reduce_to_hard`.
+ */
+function reduceDrumsToHard(timed: TimedNote[]): TimedNote[] {
+  const out: TimedNote[] = []
+  const lastHit: Record<number, number> = { 0: -1000, 1: -1000, 2: -1000, 3: -1000, 4: -1000 }
+  let hihatCount = 0
+  let prevHihat = -1000
+
+  for (const item of timed) {
+    const lane = laneIndexOf(item.note)
+
+    // Ghost notes: STRUM only has velocity to go on; the editor also has an
+    // explicit flag, so honour either signal.
+    if (item.note.flags?.isGhost || item.note.velocity < 60) continue
+
+    const minGap = lane === 2 ? 100 : 80
+    if (item.ms - lastHit[lane] < minGap) continue
+
+    if (lane === 2) {
+      if (item.ms - prevHihat < 150) {
+        hihatCount += 1
+        if (hihatCount % 3 === 0) continue
+      } else {
+        hihatCount = 0
+      }
+      prevHihat = item.ms
+    }
+
+    out.push(item)
+    lastHit[lane] = item.ms
+  }
+  return out
+}
+
+/**
+ * Medium (~50%): kick to a basic pulse (no double kick), hi-hat halved, toms
+ * only on loud accents. Mirrors strum `_reduce_to_medium`.
+ */
+function reduceDrumsToMedium(timed: TimedNote[]): TimedNote[] {
+  const out: TimedNote[] = []
+  let prevKick = -1000
+  let prevSnare = -1000
+  let prevHihat = -1000
+  let hihatCount = 0
+
+  for (const item of timed) {
+    const lane = laneIndexOf(item.note)
+
+    if (lane === 0) {
+      // Double-kick is an Expert-only device; it must not survive to Medium.
+      if (item.note.flags?.isDoubleKick) continue
+      if (item.ms - prevKick < 200) continue
+      prevKick = item.ms
+    } else if (lane === 1) {
+      if (item.ms - prevSnare < 150) continue
+      prevSnare = item.ms
+    } else if (lane === 2) {
+      hihatCount += 1
+      if (hihatCount % 2 === 0) continue
+      if (item.ms - prevHihat < 180) continue
+      prevHihat = item.ms
+    } else if (item.note.velocity < 80) {
+      continue
+    }
+
+    out.push(item)
+  }
+  return out
+}
+
+/**
+ * Easy (~25-30%): kick and snare only, very sparse, no cymbals.
+ * Mirrors strum `_reduce_to_easy`.
+ */
+function reduceDrumsToEasy(timed: TimedNote[]): TimedNote[] {
+  const out: TimedNote[] = []
+  const lastLane: Record<number, number> = { 0: -1000, 1: -1000 }
+  let lastAny = -1000
+
+  for (const item of timed) {
+    const lane = laneIndexOf(item.note)
+    if (lane > 1) continue
+    if (item.ms - lastLane[lane] < 250) continue
+    // No simultaneous kick+snare on Easy.
+    if (item.ms - lastAny < 150) continue
+
+    out.push(item)
+    lastLane[lane] = item.ms
+    lastAny = item.ms
+  }
+  return out
+}
+
+function reduceDrums(
+  expert: Note[],
+  tempoEvents: TempoEvent[],
+  target: DerivedDifficulty
+): Note[] {
+  const timed = withTimes(expert, tempoEvents)
+  const hard = reduceDrumsToHard(timed)
+  const chain =
+    target === 'hard' ? hard : target === 'medium' ? reduceDrumsToMedium(hard) : reduceDrumsToEasy(reduceDrumsToMedium(hard))
+
+  return chain.map((item) => {
+    const lane = item.note.lane as DrumLane
+    if (target === 'easy') {
+      // Easy has no cymbals and no double kick; fold anything that survived.
+      const folded = CYMBAL_TO_TOM[lane] ?? lane
+      return derive(item.note, target, {
+        lane: folded,
+        duration: 0,
+        flags: { ...item.note.flags, isCymbal: false, isGhost: false, isDoubleKick: false }
+      })
+    }
+    if (target === 'medium') {
+      return derive(item.note, target, {
+        duration: 0,
+        flags: { ...item.note.flags, isGhost: false, isDoubleKick: false }
+      })
+    }
+    return derive(item.note, target, { duration: 0, flags: { ...item.note.flags, isGhost: false } })
+  })
+}
+
+// ─── Guitar / Bass (5-fret) ──────────────────────────────────────────────────
+
+// C3 fret indices: 0=Green 1=Red 2=Yellow 3=Blue 4=Orange. 'open' has no index —
+// it is a strum of the open string and is preserved rather than fret-capped.
+const GUITAR_LANE_INDEX: Record<Exclude<GuitarLane, 'open'>, number> = {
+  green: 0,
+  red: 1,
+  yellow: 2,
+  blue: 3,
+  orange: 4
+}
+const INDEX_TO_GUITAR_LANE: Exclude<GuitarLane, 'open'>[] = [
+  'green',
+  'red',
+  'yellow',
+  'blue',
+  'orange'
+]
+
+/** Forbidden 2-note chord shapes per difficulty (c3_rules `_FORBIDDEN_2CHORD`). */
+const FORBIDDEN_2CHORD: Record<Difficulty, Set<string>> = {
+  expert: new Set(),
+  hard: new Set(['0,4']),
+  medium: new Set(['0,3', '0,4', '1,4']),
+  easy: new Set([
+    '0,1',
+    '0,2',
+    '0,3',
+    '0,4',
+    '1,2',
+    '1,3',
+    '1,4',
+    '2,3',
+    '2,4',
+    '3,4'
+  ])
+}
+
+/** c3_rules `_fix_chord_shape` — return a fret set legal for `difficulty`. */
+function fixChordShape(fretsIn: number[], difficulty: Difficulty): number[] {
+  let frets = Array.from(new Set(fretsIn)).sort((a, b) => a - b)
+  if (frets.length === 0) return frets
+
+  if (difficulty === 'easy') return [frets[0]]
+
+  if (frets.length >= 3) {
+    if (difficulty === 'expert') {
+      if (frets.includes(0) && frets.includes(4)) {
+        frets = frets.filter((f) => f !== 4)
+        if (frets.length < 2) return frets.slice(0, 1)
+      }
+    } else {
+      // Hard / Medium take no 3-note chords — reduce to the outer two.
+      frets = [frets[0], frets[frets.length - 1]]
+    }
+  }
+
+  if (frets.length === 2) {
+    const key = `${frets[0]},${frets[1]}`
+    if (FORBIDDEN_2CHORD[difficulty].has(key)) {
+      // Hard prefers remapping GO → GB rather than dropping to a single note.
+      if (difficulty === 'hard' && key === '0,4') return [0, 3]
+      return [frets[0]]
+    }
+  }
+
+  return frets
+}
+
+/** Notes shorter than this (3/16 of a beat, ≈ dotted 8th) lose their sustain tail. */
+function minSustainMs(bpm: number): number {
+  return 0.75 * (60000 / Math.max(bpm, 30))
+}
+
+/** Required silence between a sustain end and the next onset (1/32 note). */
+function minGapMs(bpm: number): number {
+  return 60000 / Math.max(bpm, 30) / 8
+}
+
+interface GuitarEvent {
+  tick: number
+  ms: number
+  durationMs: number
+  frets: number[]
+  open: boolean
+  source: Note
+}
+
+/**
+ * Thinning stage — strum `_reduce_hard/_reduce_medium/_reduce_easy`. Operates on
+ * chord groups (one entry per onset) so a chord counts once, matching STRUM's
+ * de-duplication of chord notes sharing a time.
+ */
+function thinGuitarGroups(
+  groups: TimedNote[][],
+  target: DerivedDifficulty,
+  isBass: boolean
+): TimedNote[][] {
+  const out: TimedNote[][] = []
+  let skipCounter = 0
+
+  for (let i = 0; i < groups.length; i++) {
+    if (i > 0) {
+      const gap = groups[i][0].ms - groups[i - 1][0].ms
+      let skip = false
+
+      if (target === 'hard') {
+        const gapThreshold = isBass ? 500 : 350
+        const skipMod = isBass ? 5 : 3
+        if (gap < gapThreshold) {
+          skipCounter += 1
+          if (skipCounter % skipMod === 0) skip = true
+        } else {
+          skipCounter = 0
+        }
+      } else if (target === 'medium') {
+        if (isBass) {
+          if (gap < 500) {
+            skipCounter += 1
+            if (skipCounter % 3 === 0) skip = true
+          } else {
+            skipCounter = 0
+          }
+        } else if (gap < 200) {
+          skipCounter += 1
+          if (skipCounter % 2 === 0) skip = true
+        } else if (gap < 500) {
+          skipCounter += 1
+          if (skipCounter % 3 === 0) skip = true
+        } else {
+          skipCounter = 0
+        }
+      } else {
+        // Easy keeps only 1-in-N through fast passages.
+        if (isBass) {
+          if (gap < 400) {
+            skipCounter += 1
+            if (skipCounter % 3 !== 0) skip = true
+          } else if (gap < 700) {
+            skipCounter += 1
+            if (skipCounter % 2 !== 0) skip = true
+          } else {
+            skipCounter = 0
+          }
+        } else if (gap < 400) {
+          skipCounter += 1
+          if (skipCounter % 4 !== 0) skip = true
+        } else if (gap < 800) {
+          skipCounter += 1
+          if (skipCounter % 2 !== 0) skip = true
+        } else {
+          skipCounter = 0
+        }
+      }
+
+      if (skip) continue
+    }
+    out.push(groups[i])
+  }
+  return out
+}
+
+function reduceGuitar(
+  expert: Note[],
+  tempoEvents: TempoEvent[],
+  target: DerivedDifficulty,
+  isBass: boolean
+): Note[] {
+  const groups = groupByTick(withTimes(expert, tempoEvents))
+  const kept = thinGuitarGroups(groups, target, isBass)
+
+  const fretCap = target === 'easy' ? 2 : 3
+
+  // Build one event per onset, capping frets the way STRUM does before the C3 pass.
+  const events: GuitarEvent[] = kept.map((group) => {
+    const open = group.some((g) => g.note.lane === 'open')
+    const frets = group
+      .filter((g) => g.note.lane !== 'open')
+      .map((g) => GUITAR_LANE_INDEX[g.note.lane as Exclude<GuitarLane, 'open'>] ?? 0)
+      .map((f) => Math.min(f, fretCap))
+    const longest = group.reduce((a, b) => (b.endMs - b.ms > a.endMs - a.ms ? b : a))
+    return {
+      tick: group[0].note.tick,
+      ms: group[0].ms,
+      durationMs: longest.endMs - longest.ms,
+      frets,
+      open,
+      source: longest.note
+    }
+  })
+
+  // C3 chord-shape rules. An open strum is a single event on its own — it can't
+  // be combined with fretted notes, so when both land on one tick the open wins
+  // and the fretted notes are dropped, which is what the games expect.
+  const shaped = events
+    .map((ev) => {
+      if (ev.open) return { ...ev, frets: [] }
+      return { ...ev, frets: fixChordShape(ev.frets, target) }
+    })
+    .filter((ev) => ev.open || ev.frets.length > 0)
+
+  // Tempo-aware sustains + no-overlap enforcement (c3_rules steps 3 and 4).
+  const SHORT_NOTE_MS = 80
+  for (let i = 0; i < shaped.length; i++) {
+    const bpm = bpmAt(shaped[i].tick, tempoEvents)
+    if (shaped[i].durationMs < minSustainMs(bpm)) shaped[i].durationMs = SHORT_NOTE_MS
+  }
+  for (let i = 0; i < shaped.length - 1; i++) {
+    const bpm = bpmAt(shaped[i].tick, tempoEvents)
+    const gap = minGapMs(bpm)
+    const maxEnd = shaped[i + 1].ms - gap
+    const end = shaped[i].ms + shaped[i].durationMs
+    if (end > maxEnd) {
+      const fits = maxEnd - shaped[i].ms
+      shaped[i].durationMs = fits < SHORT_NOTE_MS ? Math.max(20, fits) : Math.max(SHORT_NOTE_MS, fits)
+    }
+  }
+
+  // Back to editor notes. Durations are converted from ms to ticks against the
+  // local tempo so the sustain enforcement above survives tempo changes.
+  const out: Note[] = []
+  for (const ev of shaped) {
+    const bpm = bpmAt(ev.tick, tempoEvents)
+    const ticksPerMs = (480 * bpm) / 60 / 1000
+    const durationTicks = Math.max(0, Math.round(ev.durationMs * ticksPerMs))
+    // A tap/short note carries no tail in the editor's model.
+    const duration = ev.durationMs <= SHORT_NOTE_MS ? 0 : durationTicks
+
+    const lanes: GuitarLane[] = ev.open ? ['open'] : ev.frets.map((f) => INDEX_TO_GUITAR_LANE[f])
+    for (const lane of lanes) {
+      out.push(
+        derive(ev.source, target, {
+          tick: ev.tick,
+          lane,
+          duration,
+          flags: {
+            ...ev.source.flags,
+            // Medium and Easy are strum-only; Hard keeps HOPOs but never taps.
+            isHOPO: target === 'hard' ? ev.source.flags?.isHOPO : false,
+            isTap: false
+          }
+        })
+      )
+    }
+  }
+  return out
+}
+
+// ─── Keys (5-lane) and Pro Keys ──────────────────────────────────────────────
+
+/**
+ * Deterministic stride reduction, matching the keys/pro-keys behaviour in
+ * strum `batch_pipeline._create_keys_track` / `_create_prokeys_track`:
+ * Hard drops every 4th note, Medium keeps every other, Easy keeps every 3rd.
+ */
+function strideKeep<T>(items: T[], target: DerivedDifficulty): T[] {
+  if (target === 'hard') return items.filter((_, i) => i % 4 !== 0)
+  if (target === 'medium') return items.filter((_, i) => i % 2 === 0)
+  return items.filter((_, i) => i % 3 === 0)
+}
+
+function reduceKeys(
+  expert: Note[],
+  tempoEvents: TempoEvent[],
+  target: DerivedDifficulty
+): Note[] {
+  // Stride on chord groups, not raw notes, so a chord is kept or dropped whole
+  // instead of being torn apart into an unplayable fragment.
+  const groups = groupByTick(withTimes(expert, tempoEvents))
+  const kept = strideKeep(groups, target)
+
+  return kept.flatMap((group) => {
+    // Keys chords thin with difficulty: Medium takes two lanes, Easy one.
+    const limit = target === 'hard' ? group.length : target === 'medium' ? 2 : 1
+    return group
+      .slice(0, limit)
+      .map((item) => derive(item.note, target, { flags: { ...item.note.flags, isTap: false } }))
+  })
+}
+
+function reduceProKeys(
+  expert: Note[],
+  tempoEvents: TempoEvent[],
+  target: DerivedDifficulty
+): Note[] {
+  const groups = groupByTick(withTimes(expert, tempoEvents))
+  const kept = strideKeep(groups, target)
+
+  return kept.flatMap((group) => {
+    // Pro Keys keeps real pitches; reduce the size of simultaneous voicings
+    // rather than remapping them. Easy is melody only (top voice).
+    const sorted = [...group].sort((a, b) => Number(a.note.lane) - Number(b.note.lane))
+    const limit = target === 'hard' ? sorted.length : target === 'medium' ? 2 : 1
+    const chosen = target === 'easy' ? [sorted[sorted.length - 1]] : sorted.slice(0, limit)
+    return chosen.map((item) => derive(item.note, target))
+  })
+}
+
+// ─── Pro Guitar / Pro Bass ───────────────────────────────────────────────────
+
+/**
+ * STRUM has no Pro Guitar/Bass reducer, so these rules are OCTAVE's own. They
+ * follow the same shape as the 5-fret ones — thin by onset gap, then shrink
+ * chord voicings — but operate on strings rather than lanes and never transpose
+ * a fret, because moving a fret changes the actual note being played.
+ *
+ * Hard   — thin dense passages, cap voicings at 4 strings, drop no frets.
+ * Medium — cap voicings at 2 strings (keep the lowest two), thin harder.
+ * Easy   — single notes only (lowest string of each voicing), sparsest.
+ */
+function reduceProGuitar(
+  expert: Note[],
+  tempoEvents: TempoEvent[],
+  target: DerivedDifficulty,
+  isBass: boolean
+): Note[] {
+  const groups = groupByTick(withTimes(expert, tempoEvents))
+  const kept = thinGuitarGroups(groups, target, isBass)
+  const stringLimit = target === 'hard' ? 4 : target === 'medium' ? 2 : 1
+
+  return kept.flatMap((group) => {
+    // `string` 1 = high E … 6 = low E, so descending order keeps the low
+    // strings — the root of the voicing — which is what lower difficulties play.
+    const sorted = [...group].sort(
+      (a, b) => ((b.note.string ?? 6) as number) - ((a.note.string ?? 6) as number)
+    )
+    return sorted.slice(0, stringLimit).map((item) =>
+      derive(item.note, target, {
+        string: (item.note.string ?? 6) as ProGuitarString,
+        fret: item.note.fret,
+        flags: {
+          ...item.note.flags,
+          isHOPO: target === 'hard' ? item.note.flags?.isHOPO : false,
+          isTap: false
+        }
+      })
+    )
+  })
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+export interface GenerateFromExpertOptions {
+  /** Instruments to reduce. Defaults to every reducible instrument with Expert notes. */
+  instruments?: Instrument[]
+  /** Difficulties to write. Defaults to Hard + Medium + Easy. */
+  targets?: DerivedDifficulty[]
+}
+
+export interface GenerateFromExpertResult {
+  /** The full replacement note list for the song. */
+  notes: Note[]
+  /** Per-instrument, per-difficulty counts of what was generated. */
+  generated: Record<string, Partial<Record<DerivedDifficulty, number>>>
+  /** Instruments that were asked for but had no Expert notes to reduce. */
+  skipped: Instrument[]
+}
+
+function reduceForInstrument(
+  instrument: Instrument,
+  expert: Note[],
+  tempoEvents: TempoEvent[],
+  target: DerivedDifficulty
+): Note[] {
+  switch (instrument) {
+    case 'drums':
+      return reduceDrums(expert, tempoEvents, target)
+    case 'guitar':
+      return reduceGuitar(expert, tempoEvents, target, false)
+    case 'bass':
+      return reduceGuitar(expert, tempoEvents, target, true)
+    case 'keys':
+      return reduceKeys(expert, tempoEvents, target)
+    case 'proKeys':
+      return reduceProKeys(expert, tempoEvents, target)
+    case 'proGuitar':
+      return reduceProGuitar(expert, tempoEvents, target, false)
+    case 'proBass':
+      return reduceProGuitar(expert, tempoEvents, target, true)
+    default:
+      return []
+  }
+}
+
+/**
+ * Derive lower difficulties from the Expert chart.
+ *
+ * Returns a complete replacement note list: notes for the targeted
+ * instrument/difficulty pairs are replaced wholesale, and everything else
+ * (Expert, untargeted instruments, untargeted difficulties) is passed through
+ * untouched. Callers are responsible for confirming the overwrite with the user
+ * — any hand-authored work on a targeted difficulty is discarded.
+ */
+export function generateFromExpert(
+  notes: Note[],
+  tempoEvents: TempoEvent[],
+  options: GenerateFromExpertOptions = {}
+): GenerateFromExpertResult {
+  const targets = options.targets?.length ? options.targets : DERIVED_DIFFICULTIES
+  const requested = options.instruments?.length
+    ? options.instruments.filter((i) => REDUCIBLE_INSTRUMENTS.includes(i))
+    : REDUCIBLE_INSTRUMENTS
+
+  const generated: GenerateFromExpertResult['generated'] = {}
+  const skipped: Instrument[] = []
+  const replacedPairs = new Set<string>()
+  const additions: Note[] = []
+
+  for (const instrument of requested) {
+    const expert = notes.filter((n) => n.instrument === instrument && n.difficulty === 'expert')
+    if (expert.length === 0) {
+      // Nothing to reduce — leave any existing lower difficulties alone rather
+      // than wiping them because Expert happens to be empty.
+      skipped.push(instrument)
+      continue
+    }
+
+    for (const target of targets) {
+      const produced = reduceForInstrument(instrument, expert, tempoEvents, target)
+      replacedPairs.add(`${instrument}|${target}`)
+      additions.push(...produced)
+      generated[instrument] = { ...generated[instrument], [target]: produced.length }
+    }
+  }
+
+  const kept = notes.filter((n) => !replacedPairs.has(`${n.instrument}|${n.difficulty}`))
+  return { notes: [...kept, ...additions], generated, skipped }
+}


### PR DESCRIPTION
Cuts the stable release from `beta` (currently published as `v1.0.25-beta.1`).

## Included

- **feat: Generate from Expert** (#53, fixes #51) — derive Hard / Medium / Easy from an Expert chart via a piano-roll toolbar button, using a TypeScript port of the reduction rules STRUM already runs during Auto-Chart. Covers drums, guitar, bass, keys, Pro Keys and Pro Guitar/Bass.
- Fixes toolbar popovers being clipped at the bottom of the window (affected **Swap Lanes** too — its Generate/Cancel row could sit off screen).
- Docs: documents the feature and its limits, and corrects the Lane swap section, which described a left-to-right mirror the tool never was.

Beta build passed on macOS, Windows and Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
