### PR TITLE
feat(training): export MIDI from SNG packages

### DIFF
--- a/src/main/import/sngTrainingExporter.test.ts
+++ b/src/main/import/sngTrainingExporter.test.ts
@@ -1,0 +1,164 @@
+import { existsSync } from 'fs'
+import { mkdir, readFile, rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { packSng } from '../sngPacker'
+import { exportSngTrainingMidi } from './sngTrainingExporter'
+
+describe('exportSngTrainingMidi', () => {
+  const testDir = join(__dirname, '../../../out/sng_training_exporter_test_temp')
+  const validMidi = Buffer.from([
+    0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, 0x00, 0x01, 0x00, 0x01, 0x01, 0xe0, 0x4d, 0x54,
+    0x72, 0x6b, 0x00, 0x00, 0x00, 0x04, 0x00, 0xff, 0x2f, 0x00
+  ])
+  const truncatedMidi = Buffer.from([
+    0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, 0x00, 0x01, 0x00, 0x01, 0x01, 0xe0, 0x4d, 0x54,
+    0x72, 0x6b, 0x00, 0x00, 0x00, 0x04, 0x00, 0xff
+  ])
+
+  function emptySngPackage(): Buffer {
+    const header = Buffer.alloc(26)
+    header.write('SNGPKG')
+    header.writeUInt32LE(1, 6)
+    const metadata = Buffer.alloc(16)
+    metadata.writeBigUInt64LE(8n, 0)
+    const fileIndex = Buffer.alloc(16)
+    fileIndex.writeBigUInt64LE(8n, 0)
+    const payloadLength = Buffer.alloc(8)
+    return Buffer.concat([header, metadata, fileIndex, payloadLength])
+  }
+
+  beforeAll(async () => {
+    await mkdir(testDir, { recursive: true })
+  })
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true })
+  })
+
+  it('exports notes.mid and metadata without copying audio or source paths', async () => {
+    const songDir = join(testDir, 'source-song')
+    await mkdir(songDir, { recursive: true })
+    await writeFile(join(songDir, 'notes.mid'), validMidi)
+    await writeFile(join(songDir, 'guitar.ogg'), 'AUDIO MUST NOT BE EXPORTED')
+    const sngPath = join(testDir, 'source.sng')
+    await packSng(
+      songDir,
+      {
+        artist: 'Test Artist',
+        name: 'Test Song',
+        charter: 'Test Charter',
+        source_path: '/private/metadata/path'
+      },
+      sngPath
+    )
+
+    const outputDir = join(testDir, 'dataset')
+    const result = await exportSngTrainingMidi({
+      sngPaths: [sngPath],
+      outputDir,
+      datasetId: 'test-private-export',
+      provenance: 'synthetic test fixture',
+      license: 'test-only'
+    })
+
+    expect(result.exported).toHaveLength(1)
+    expect(result.skipped).toEqual([])
+    const [song] = result.exported
+    expect(await readFile(join(outputDir, song.midi))).toEqual(validMidi)
+    expect(existsSync(join(outputDir, 'songs', song.songId, 'guitar.ogg'))).toBe(false)
+    const manifest = await readFile(result.manifestPath, 'utf8')
+    expect(manifest).toContain('octave-sng-midi-export/v1')
+    expect(manifest).not.toContain(sngPath)
+    expect(manifest).not.toContain('/private/metadata/path')
+    const metadata = await readFile(
+      join(outputDir, 'songs', song.songId, 'source-metadata.json'),
+      'utf8'
+    )
+    expect(metadata).not.toContain('/private/metadata/path')
+  })
+
+  it('refuses to write into a non-empty output directory', async () => {
+    const outputDir = join(testDir, 'non-empty')
+    await mkdir(outputDir, { recursive: true })
+    await writeFile(join(outputDir, 'keep.txt'), 'keep')
+
+    await expect(
+      exportSngTrainingMidi({
+        sngPaths: [join(testDir, 'missing.sng')],
+        outputDir,
+        datasetId: 'test-private-export',
+        provenance: 'synthetic test fixture',
+        license: 'test-only'
+      })
+    ).rejects.toThrow('must be empty')
+  })
+
+  it('records path-free skips for missing and no-MIDI packages', async () => {
+    const chartOnlySong = join(testDir, 'chart-only')
+    await mkdir(chartOnlySong, { recursive: true })
+    await writeFile(join(chartOnlySong, 'notes.chart'), '[Song]\n{\n  Resolution = 192\n}\n')
+    const chartOnlySng = join(testDir, 'chart-only.sng')
+    await packSng(chartOnlySong, { artist: 'No Midi', name: 'Chart Only' }, chartOnlySng)
+    const missingSng = join(testDir, 'missing-private-package.sng')
+    const outputDir = join(testDir, 'skips')
+
+    const result = await exportSngTrainingMidi({
+      sngPaths: [chartOnlySng, missingSng],
+      outputDir,
+      datasetId: 'test-private-export',
+      provenance: 'synthetic test fixture',
+      license: 'test-only'
+    })
+
+    expect(result.exported).toEqual([])
+    expect(result.skipped).toEqual([
+      { sourceIndex: 0, reason: 'Package has no notes.mid' },
+      { sourceIndex: 1, reason: 'Package could not be read or exported' }
+    ])
+    const manifest = await readFile(result.manifestPath, 'utf8')
+    expect(manifest).not.toContain(chartOnlySng)
+    expect(manifest).not.toContain(missingSng)
+    expect(manifest).not.toContain('missing-private-package.sng')
+  })
+
+  it('skips packages with an empty file index without hanging or exposing paths', async () => {
+    const emptySng = join(testDir, 'empty-private-package.sng')
+    await writeFile(emptySng, emptySngPackage())
+    const outputDir = join(testDir, 'empty-package-dataset')
+
+    const result = await exportSngTrainingMidi({
+      sngPaths: [emptySng],
+      outputDir,
+      datasetId: 'test-private-export',
+      provenance: 'synthetic test fixture',
+      license: 'test-only'
+    })
+
+    expect(result.exported).toEqual([])
+    expect(result.skipped).toEqual([{ sourceIndex: 0, reason: 'Package has no notes.mid' }])
+    expect(await readFile(result.manifestPath, 'utf8')).not.toContain('empty-private-package.sng')
+  })
+
+  it('skips packages with malformed notes.mid data, even when the header looks valid', async () => {
+    const invalidSong = join(testDir, 'invalid-midi')
+    await mkdir(invalidSong, { recursive: true })
+    await writeFile(join(invalidSong, 'notes.mid'), truncatedMidi)
+    const invalidSng = join(testDir, 'invalid-midi.sng')
+    await packSng(invalidSong, { artist: 'Invalid', name: 'Midi' }, invalidSng)
+    const outputDir = join(testDir, 'invalid-midi-dataset')
+
+    const result = await exportSngTrainingMidi({
+      sngPaths: [invalidSng],
+      outputDir,
+      datasetId: 'test-private-export',
+      provenance: 'synthetic test fixture',
+      license: 'test-only'
+    })
+
+    expect(result.exported).toEqual([])
+    expect(result.skipped).toEqual([
+      { sourceIndex: 0, reason: 'Package could not be read or exported' }
+    ])
+  })
+})

--- a/src/main/import/sngTrainingExporter.ts
+++ b/src/main/import/sngTrainingExporter.ts
@@ -1,0 +1,286 @@
+import { createHash } from 'crypto'
+import { createReadStream, createWriteStream } from 'fs'
+import { mkdir, readFile, readdir, rename, rm, writeFile } from 'fs/promises'
+import * as path from 'path'
+import { Readable } from 'stream'
+import { pipeline } from 'stream/promises'
+import { Midi } from '@tonejs/midi'
+import { SngStream, type SngHeader } from 'parse-sng'
+
+const EXPORT_FORMAT = 'octave-sng-midi-export/v1'
+const NOTES_MIDI = 'notes.mid'
+const EXPORTED_METADATA_KEYS = ['name', 'artist', 'album', 'genre', 'year', 'charter'] as const
+const MAX_METADATA_VALUE_LENGTH = 512
+
+export interface SngTrainingExportOptions {
+  sngPaths: readonly string[]
+  outputDir: string
+  datasetId: string
+  provenance: string
+  license: string
+}
+
+interface ExportedSong {
+  songId: string
+  midi: string
+  notesSha256: string
+  packageSha256: string
+  metadata: Record<string, string>
+}
+
+export interface SngTrainingExportResult {
+  manifestPath: string
+  exported: ExportedSong[]
+  skipped: Array<{ sourceIndex: number; reason: string }>
+}
+
+function slug(value: string): string {
+  const normalized = value
+    .normalize('NFKD')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+  return normalized || 'unknown-song'
+}
+
+function sanitizeMetadata(metadata: Record<string, string>): Record<string, string> {
+  const sanitized: Record<string, string> = {}
+  for (const key of EXPORTED_METADATA_KEYS) {
+    const value = metadata[key]
+    if (!value) continue
+    const withoutControls = Array.from(value, (character) => {
+      const codePoint = character.codePointAt(0) ?? 0
+      return codePoint <= 0x1f || codePoint === 0x7f ? ' ' : character
+    }).join('')
+    const normalized = withoutControls.normalize('NFKC').trim().slice(0, MAX_METADATA_VALUE_LENGTH)
+    if (normalized) sanitized[key] = normalized
+  }
+  return sanitized
+}
+
+async function hasValidMidiFile(midiPath: string): Promise<boolean> {
+  try {
+    const midiBytes = await readFile(midiPath)
+    if (!hasValidMidiChunkLayout(midiBytes)) return false
+    new Midi(midiBytes)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function hasValidMidiChunkLayout(midiBytes: Buffer): boolean {
+  if (
+    midiBytes.length < 14 ||
+    midiBytes.subarray(0, 4).toString('ascii') !== 'MThd' ||
+    midiBytes.readUInt32BE(4) !== 6
+  ) {
+    return false
+  }
+
+  const trackCount = midiBytes.readUInt16BE(10)
+  if (trackCount === 0) return false
+
+  let offset = 14
+  for (let trackIndex = 0; trackIndex < trackCount; trackIndex += 1) {
+    if (
+      offset + 8 > midiBytes.length ||
+      midiBytes.subarray(offset, offset + 4).toString('ascii') !== 'MTrk'
+    ) {
+      return false
+    }
+    const trackLength = midiBytes.readUInt32BE(offset + 4)
+    offset += 8
+    if (trackLength > midiBytes.length - offset) return false
+    offset += trackLength
+  }
+  return offset === midiBytes.length
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const digest = createHash('sha256')
+  for await (const chunk of createReadStream(filePath)) {
+    digest.update(chunk)
+  }
+  return digest.digest('hex')
+}
+
+async function drain(fileStream: ReadableStream<Uint8Array>): Promise<void> {
+  for await (const chunk of Readable.fromWeb(
+    fileStream as import('stream/web').ReadableStream<Uint8Array>
+  )) {
+    void chunk
+  }
+}
+
+async function extractNotesMidi(
+  sngPath: string,
+  temporaryDir: string
+): Promise<Record<string, string> | null> {
+  return await new Promise<Record<string, string> | null>((resolve, reject) => {
+    let settled = false
+    let metadata: Record<string, string> | null = null
+    let wroteNotesMidi = false
+    let writeChain: Promise<void> = Promise.resolve()
+
+    const settle = (callback: () => void): void => {
+      if (settled) return
+      settled = true
+      callback()
+    }
+    const fail = (error: unknown): void => {
+      const normalized = error instanceof Error ? error : new Error(String(error))
+      settle(() => reject(normalized))
+    }
+
+    const input = createReadStream(sngPath)
+    const sngStream = new SngStream(Readable.toWeb(input) as ReadableStream<Uint8Array>, {
+      generateSongIni: false
+    })
+
+    sngStream.on('header', (header: SngHeader) => {
+      metadata = sanitizeMetadata(header.metadata)
+      if (header.fileMeta.length === 0) {
+        settle(() => resolve(null))
+      }
+    })
+    sngStream.on('file', (fileName, fileStream, nextFile) => {
+      writeChain = writeChain
+        .then(async () => {
+          if (fileName.toLowerCase() === NOTES_MIDI) {
+            if (wroteNotesMidi) throw new Error(`Package contains multiple ${NOTES_MIDI} files`)
+            await pipeline(
+              Readable.fromWeb(fileStream as import('stream/web').ReadableStream<Uint8Array>),
+              createWriteStream(path.join(temporaryDir, NOTES_MIDI), { flags: 'wx' })
+            )
+            wroteNotesMidi = true
+          } else {
+            await drain(fileStream as ReadableStream<Uint8Array>)
+          }
+
+          if (nextFile) {
+            nextFile()
+          } else {
+            settle(() => resolve(wroteNotesMidi && metadata ? metadata : null))
+          }
+        })
+        .catch(fail)
+    })
+    sngStream.on('error', fail)
+    sngStream.start()
+  })
+}
+
+async function ensureEmptyOutputDir(outputDir: string): Promise<void> {
+  try {
+    const entries = await readdir(outputDir)
+    if (entries.length > 0) {
+      throw new Error(`Training export output directory must be empty: ${outputDir}`)
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    await mkdir(outputDir, { recursive: true })
+  }
+}
+
+/**
+ * Stream local Clone Hero SNG packages into a MIDI-only training export.
+ * The output intentionally omits package paths, audio, and stems; callers must
+ * record appropriate source provenance and permission before model training.
+ */
+export async function exportSngTrainingMidi(
+  options: SngTrainingExportOptions
+): Promise<SngTrainingExportResult> {
+  if (!options.sngPaths.length) throw new Error('At least one SNG package is required')
+  for (const [name, value] of Object.entries({
+    datasetId: options.datasetId,
+    provenance: options.provenance,
+    license: options.license
+  })) {
+    if (!value.trim()) throw new Error(`${name} must be non-empty`)
+  }
+
+  const outputDir = path.resolve(options.outputDir)
+  await ensureEmptyOutputDir(outputDir)
+  const songsDir = path.join(outputDir, 'songs')
+  const temporaryRoot = path.join(outputDir, '.partial')
+  await mkdir(songsDir, { recursive: true })
+  await mkdir(temporaryRoot, { recursive: true })
+
+  const exported: ExportedSong[] = []
+  const skipped: Array<{ sourceIndex: number; reason: string }> = []
+  try {
+    for (const [sourceIndex, sourcePath] of options.sngPaths.entries()) {
+      const temporaryDir = path.join(temporaryRoot, String(sourceIndex))
+      await mkdir(temporaryDir)
+      try {
+        const metadata = await extractNotesMidi(sourcePath, temporaryDir)
+        if (!metadata) {
+          skipped.push({ sourceIndex, reason: `Package has no ${NOTES_MIDI}` })
+          await rm(temporaryDir, { recursive: true, force: true })
+          continue
+        }
+        const notesPath = path.join(temporaryDir, NOTES_MIDI)
+        if (!(await hasValidMidiFile(notesPath))) {
+          throw new Error(`Invalid ${NOTES_MIDI}`)
+        }
+        const [notesSha256, packageSha256] = await Promise.all([
+          sha256File(notesPath),
+          sha256File(sourcePath)
+        ])
+        const songId = `${slug(`${metadata.artist ?? ''}-${metadata.name ?? ''}`)}-${notesSha256.slice(0, 12)}`
+        const songDir = path.join(songsDir, songId)
+        try {
+          await mkdir(songDir)
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+            skipped.push({ sourceIndex, reason: `Duplicate notes.mid: ${songId}` })
+            await rm(temporaryDir, { recursive: true, force: true })
+            continue
+          }
+          throw error
+        }
+        await rename(notesPath, path.join(songDir, NOTES_MIDI))
+        await writeFile(
+          path.join(songDir, 'source-metadata.json'),
+          JSON.stringify({ metadata, notesSha256, packageSha256 }, null, 2) + '\n',
+          'utf8'
+        )
+        exported.push({
+          songId,
+          midi: path.posix.join('songs', songId, NOTES_MIDI),
+          notesSha256,
+          packageSha256,
+          metadata
+        })
+        await rm(temporaryDir, { recursive: true, force: true })
+      } catch (error) {
+        await rm(temporaryDir, { recursive: true, force: true })
+        void error
+        skipped.push({ sourceIndex, reason: 'Package could not be read or exported' })
+      }
+    }
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true })
+  }
+
+  const manifestPath = path.join(outputDir, 'source-manifest.json')
+  await writeFile(
+    manifestPath,
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        format: EXPORT_FORMAT,
+        datasetId: options.datasetId,
+        provenance: options.provenance,
+        license: options.license,
+        exported,
+        skipped
+      },
+      null,
+      2
+    ) + '\n',
+    'utf8'
+  )
+  return { manifestPath, exported, skipped }
+}


### PR DESCRIPTION
## Summary
- stream local SNG packages into a MIDI-only, provenance-aware dataset export
- retain only notes.mid, allowlisted metadata, and content hashes; exclude audio, stems, package files, and source paths
- reject invalid/truncated MIDI, duplicate charts, and non-empty destinations

## Validation
- npx vitest run src/main/import/sngTrainingExporter.test.ts (5 passed)
- npm run typecheck:node
- npx eslint --no-cache src/main/import/sngTrainingExporter.ts src/main/import/sngTrainingExporter.test.ts
- git diff --check

This is intentionally a narrow main-process export primitive. UI/IPC and the batched local-library workflow can build on it in follow-up MRs.