### PR TITLE
docs: define canonical song source catalog

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -78,7 +78,8 @@ export default defineConfig({
           items: [
             { text: 'Keyboard Shortcuts', link: '/reference/keyboard-shortcuts' },
             { text: 'Settings', link: '/reference/settings' },
-            { text: 'File Formats', link: '/reference/file-formats' }
+            { text: 'File Formats', link: '/reference/file-formats' },
+            { text: 'Song Source Catalog', link: '/reference/song-source-catalog' }
           ]
         }
       ],

--- a/docs/reference/song-source-catalog.md
+++ b/docs/reference/song-source-catalog.md
@@ -1,0 +1,171 @@
+# Song Source Catalog
+
+`octave-song-source-catalog/v1` is OCTAVE's canonical, local-first intake
+format for chart sources. It is the boundary between package import and model
+training: import adapters understand `.sng`, `.con`/`.rb3con`, ZIP archives,
+and song folders; STRUM consumes normalized catalog records and never parses
+those containers directly.
+
+The normative schema is [song-source-catalog.schema.json](./song-source-catalog.schema.json).
+
+## Layout
+
+```text
+my-catalog/
+├── catalog.json             # `octave-song-source-catalog/v1` manifest
+├── records.jsonl            # one validated source record per song
+└── assets/
+    └── sha256/<hash>/...    # OCTAVE-managed materialized MIDI/audio assets
+```
+
+`catalog.json.records` is a relative JSONL path. A catalog record contains a
+stable `source_id`, content hashes, normalized metadata, chart coverage, a
+rights decision, and references only to materialized assets under `assets/`.
+It never contains the original package path, SMB path, URL, user home path, or
+raw parser error.
+
+```json
+{
+  "source_id": "octave-src-4fa0a8d2",
+  "import": {
+    "kind": "sng",
+    "adapter_version": "octave-sng/1",
+    "container_sha256": "…",
+    "warnings": [{"code": "missing_optional_artwork"}]
+  },
+  "rights": {
+    "training_use": "allowed",
+    "provenance": "Reviewed local collection",
+    "license": "Permission recorded by catalog owner"
+  },
+  "chart": {
+    "notes_midi": {
+      "asset_id": "sha256:…",
+      "sha256": "…",
+      "relative_path": "assets/sha256/…/notes.mid",
+      "byte_length": 12345,
+      "media_type": "audio/midi"
+    },
+    "instruments": {
+      "guitar": {
+        "status": "present",
+        "difficulties": ["easy", "medium", "hard", "expert"],
+        "track_names": ["PART GUITAR"]
+      }
+    }
+  }
+}
+```
+
+## Ownership boundary
+
+### OCTAVE owns
+
+- Adapter selection, archive parsing, safe extraction, and import warnings.
+- Metadata normalization, MIDI validation, instrument/difficulty discovery,
+  hashing, duplicate handling, and catalog materialization.
+- The user-facing rights decision. `training_use` starts as `review_required`;
+  only an explicit review may set it to `allowed`.
+- Private original-location bookkeeping, if needed for refresh or reveal in
+  the file browser. That resolver is a local OCTAVE sidecar and is neither a
+  catalog asset nor a training artifact.
+
+### STRUM owns
+
+- Selecting `training_use: allowed` records and creating task-specific views.
+- Converting catalog chart/audio assets into model examples, windows, tokens,
+  targets, splits, and evaluation manifests.
+- Recording catalog `source_id`s and input hashes in experiment metadata.
+- Rejecting records with missing assets, hash mismatches, or non-allowed
+  training rights.
+
+STRUM must not infer rights, persist source locations, or add SNG/RB3CON/ZIP
+parsers. OCTAVE must not encode STRUM model tokens or prescribe a model
+architecture.
+
+## Task views, not new source formats
+
+One catalog can produce many STRUM datasets without duplicating source
+metadata:
+
+| STRUM task | Catalog inputs | Derived view |
+| --- | --- | --- |
+| Audio to chart | `audio` + `chart.notes_midi` | instrument-specific onset/lane targets |
+| Difficulty transform | `chart.notes_midi` | source/target difficulty event pairs |
+| Vocal model | `chart.notes_midi` + `audio.vocals` | phrase, lyric, and pitch targets |
+| Pro instrument model | `chart.notes_midi` + stem/mix | string/fret or chromatic-key targets |
+
+Views contain `source_id`, selected asset hashes, view-builder version, and
+their own split assignment. They do not copy rights text or absolute paths.
+
+## Mandatory safety validation
+
+Schema validation is necessary but not sufficient. The catalog service must
+perform these semantic checks before writing a record or returning a UI result:
+
+- Run `redactLocationText` on every metadata, provenance, license, warning,
+  log, and error value that crosses an import boundary. It replaces filesystem
+  locations and URLs with `[redacted]`, removes control characters, normalizes
+  Unicode, and applies the schema's safe-text limits. Never persist raw parser
+  exceptions; `import.warnings` contains stable safe codes only.
+- Require `asset_id` to equal `sha256:` plus the asset's declared SHA-256, then
+  hash the materialized file and compare it to both values. Require the
+  `assets/sha256/<hash>/` directory component to equal that same declared
+  SHA-256; a correct file under a different hash directory is invalid.
+- Accept only `assets/sha256/<64-lowercase-hex>/<safe-filename>` paths. Before
+  every write or read, resolve/realpath the asset and prove it remains under
+  the real catalog root. Reject absolute paths, drive-qualified paths,
+  backslashes, symlinks escaping the root, and every traversal attempt.
+- Treat `audio` as a keyed role map. A record has at most one asset for each
+  role, so STRUM can deterministically choose `audio.guitar`, `audio.vocals`,
+  or `audio.mix`.
+- Require coverage consistency: `present` has non-empty difficulties and track
+  names; `absent` and `unsupported` have neither. Display violations to the
+  curator as a safe validation code, never as a raw source path.
+
+These checks must have fixture tests for POSIX paths, Windows drive/UNC paths,
+URLs, path-bearing parser exceptions, mismatched asset IDs/hashes, duplicate
+audio roles, and partial catalog directories.
+
+## UI handoff: Dataset Curation
+
+The Dataset Curation UI is a review and selection surface, not a second
+importer or tokenization layer.
+
+1. Let the user select packages/folders through the existing trusted file
+   dialogs, or select songs from the open OCTAVE library.
+2. Show the normalized candidate summary supplied by the catalog service:
+   source kind, sanitized metadata, MIDI validity, instrument coverage,
+   duplicate status, import warnings, and rights status.
+3. Require an explicit provenance and license/permission basis before setting
+   `training_use` to `allowed`. STRUM-generated songs remain
+   `review_required` by default.
+4. Ask the user for a parent directory and a new catalog name. The final
+   `<parent>/<name>` destination must not already exist; an existing empty
+   directory is not an atomic destination. Materialize approved assets through
+   a sibling `<parent>/.<name>.staging-<random>` directory on the same volume.
+   Hash and validate every staged asset, write and validate `records.jsonl` and
+   `catalog.json`, then atomically rename the staging directory to the new
+   destination. On failure, remove the staging directory and leave no catalog
+   marker at the destination.
+5. Hand STRUM the catalog directory. Do not hand it the original package paths
+   or put those paths in renderer state, exported manifests, logs, or errors.
+
+STRUM rejects a catalog without both root files, with a staging marker, or with
+any asset/hash validation failure. It never tries to repair an incomplete
+catalog.
+
+The current MIDI-only export is a transitional projection. It should become a
+catalog projection: the UI calls one catalog build operation, and the existing
+MIDI exporter reads allowed catalog records rather than re-parsing source
+packages.
+
+## Validation and evolution
+
+- Validate `catalog.json` against the schema and each JSONL record against
+  `#/$defs/record` before STRUM sees the catalog.
+- Resolve every asset path relative to the catalog root, reject traversal, and
+  verify the declared SHA-256 before use.
+- Deduplicate by canonical materialized asset hashes, not display metadata.
+- Add fields only in a backward-compatible minor revision; publish a new
+  `.../v2` format for breaking changes. Consumers reject unknown major formats.

--- a/docs/reference/song-source-catalog.schema.json
+++ b/docs/reference/song-source-catalog.schema.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://octavestudio.tools/schemas/song-source-catalog/v1/catalog.schema.json",
+  "title": "OCTAVE Song Source Catalog v1",
+  "description": "Portable catalog manifest for locally materialized rhythm-game song sources.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "format", "catalog_id", "records"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "format": { "const": "octave-song-source-catalog/v1" },
+    "catalog_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "records": {
+      "type": "string",
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[^\\\\]+\\.jsonl$"
+    },
+    "created_by": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["product", "version"],
+      "properties": {
+        "product": { "const": "octave" },
+        "version": { "type": "string", "minLength": 1 },
+        "source_revision": { "type": "string", "minLength": 1 }
+      }
+    }
+  },
+  "$defs": {
+    "asset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["asset_id", "sha256", "relative_path", "byte_length"],
+      "properties": {
+        "asset_id": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+        "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "relative_path": {
+          "type": "string",
+          "pattern": "^assets/sha256/[a-f0-9]{64}/[A-Za-z0-9._-]+$"
+        },
+        "byte_length": { "type": "integer", "minimum": 0 },
+        "media_type": { "type": "string", "minLength": 1 }
+      }
+    },
+    "instrumentCoverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "difficulties", "track_names"],
+      "properties": {
+        "status": { "enum": ["present", "absent", "unsupported"] },
+        "difficulties": {
+          "type": "array",
+          "items": { "enum": ["easy", "medium", "hard", "expert"] },
+          "uniqueItems": true
+        },
+        "track_names": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "status": { "const": "present" },
+            "difficulties": { "minItems": 1 },
+            "track_names": { "minItems": 1 }
+          }
+        },
+        {
+          "properties": {
+            "status": { "enum": ["absent", "unsupported"] },
+            "difficulties": { "maxItems": 0 },
+            "track_names": { "maxItems": 0 }
+          }
+        }
+      ]
+    },
+    "record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_id", "import", "rights", "metadata", "chart"],
+      "properties": {
+        "source_id": { "type": "string", "pattern": "^octave-src-[a-z0-9][a-z0-9-]{7,127}$" },
+        "import": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "adapter_version"],
+          "properties": {
+            "kind": { "enum": ["sng", "rb3con", "zip", "song_folder"] },
+            "adapter_version": { "type": "string", "minLength": 1 },
+            "container_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+            "warnings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["code"],
+                "properties": {
+                  "code": { "type": "string", "pattern": "^[a-z][a-z0-9_.-]{0,127}$" }
+                }
+              }
+            }
+          }
+        },
+        "rights": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["training_use", "provenance", "license"],
+          "properties": {
+            "training_use": { "enum": ["allowed", "review_required", "prohibited"] },
+            "provenance": { "$ref": "#/$defs/safeText" },
+            "license": { "$ref": "#/$defs/safeText" }
+          }
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "$ref": "#/$defs/safeText" },
+            "artist": { "$ref": "#/$defs/safeText" },
+            "album": { "$ref": "#/$defs/safeText" },
+            "genre": { "$ref": "#/$defs/safeText" },
+            "year": { "$ref": "#/$defs/safeText" },
+            "charter": { "$ref": "#/$defs/safeText" }
+          }
+        },
+        "chart": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["notes_midi", "instruments"],
+          "properties": {
+            "notes_midi": { "$ref": "#/$defs/asset" },
+            "instruments": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "drums": { "$ref": "#/$defs/instrumentCoverage" },
+                "guitar": { "$ref": "#/$defs/instrumentCoverage" },
+                "bass": { "$ref": "#/$defs/instrumentCoverage" },
+                "keys": { "$ref": "#/$defs/instrumentCoverage" },
+                "vocals": { "$ref": "#/$defs/instrumentCoverage" },
+                "pro_keys": { "$ref": "#/$defs/instrumentCoverage" },
+                "pro_guitar": { "$ref": "#/$defs/instrumentCoverage" },
+                "pro_bass": { "$ref": "#/$defs/instrumentCoverage" }
+              }
+            }
+          }
+        },
+        "audio": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "mix": { "$ref": "#/$defs/asset" },
+            "drums": { "$ref": "#/$defs/asset" },
+            "guitar": { "$ref": "#/$defs/asset" },
+            "bass": { "$ref": "#/$defs/asset" },
+            "keys": { "$ref": "#/$defs/asset" },
+            "vocals": { "$ref": "#/$defs/asset" },
+            "other": { "$ref": "#/$defs/asset" }
+          }
+        }
+      }
+    },
+    "safeText": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!.*(?:^|\\s)(?:file:|https?:|smb:|/|[A-Za-z]:[\\\\/]))[^\\\\\\r\\n]+$"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- define the Octave-owned `octave-song-source-catalog/v1` intake contract and JSON Schema
- establish Octave/STRUM ownership boundaries and task-view rules
- provide Dataset Curation UI implementation handoff, including permissions, privacy redaction, validation, and atomic materialization

## Safety contract
- no original paths, URLs, raw parser errors, or source locations in catalog/task views
- hash-addressed, root-contained materialized assets only
- explicit `training_use` decision; STRUM accepts only `allowed` records

## Validation
- JSON Schema parse/contract smoke check
- `npm run docs:build`
- `git diff --check`
- independent architecture/privacy review

Implementation is intentionally separate from this normative format MR.