### PR TITLE
fix: surface the vocal pitch playback toggle in the chart preview

### DIFF
--- a/src/renderer/src/components/MidiEditor.tsx
+++ b/src/renderer/src/components/MidiEditor.tsx
@@ -9,6 +9,7 @@ import {
   type DerivedDifficulty
 } from '../utils/difficultyReduction'
 import { getAudioDuration, getAudioSources, onAudioLoaded, playPitchPreview, stopPitchPreview } from '../services/audioService'
+import { VocalPitchPlaybackToggle } from './VocalPitchPlaybackToggle'
 import { buildTickAlignedWaveformPeaks } from '../services/waveformService'
 import './MidiEditor.css'
 
@@ -103,29 +104,6 @@ const MIDI_EDITOR_CONFIG = {
 
 // MIDI note names for vocal pitch display
 const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
-
-// Toggle for sounding vocal note pitches while the song plays (issue #10).
-function VocalPitchPlaybackToggle(): React.JSX.Element {
-  const enabled = useUIStore((s) => s.vocalPitchPlayback)
-  const toggle = useUIStore((s) => s.toggleVocalPitchPlayback)
-  return (
-    <button
-      title={enabled
-        ? 'Pitch playback on: vocal note pitches sound while the song plays'
-        : 'Pitch playback off: click to hear vocal note pitches while the song plays'}
-      style={{
-        fontSize: 10, padding: '1px 5px', border: 'none', borderRadius: 3,
-        cursor: 'pointer', lineHeight: 1.4,
-        backgroundColor: enabled ? '#E879F9' : 'rgba(255,255,255,0.15)',
-        color: enabled ? '#000' : '#ccc',
-        boxShadow: enabled ? '0 0 6px #E879F980' : 'none'
-      }}
-      onClick={toggle}
-    >
-      🔊
-    </button>
-  )
-}
 
 function midiNoteName(midi: number): string {
   return `${NOTE_NAMES[midi % 12]}${Math.floor(midi / 12) - 1}`

--- a/src/renderer/src/components/VocalPitchPlaybackToggle.tsx
+++ b/src/renderer/src/components/VocalPitchPlaybackToggle.tsx
@@ -1,0 +1,27 @@
+// Toggle for sounding charted vocal note pitches while the song plays
+// (issues #10, #58). Shared between the MIDI editor's vocal pitch header and
+// the chart preview's vocal track overlay so the option is visible wherever
+// vocal notes are shown.
+import { useUIStore } from '../stores'
+
+export function VocalPitchPlaybackToggle({ showLabel = false }: { showLabel?: boolean }): React.JSX.Element {
+  const enabled = useUIStore((s) => s.vocalPitchPlayback)
+  const toggle = useUIStore((s) => s.toggleVocalPitchPlayback)
+  return (
+    <button
+      title={enabled
+        ? 'Pitch playback on: vocal note pitches sound while the song plays'
+        : 'Pitch playback off: click to hear vocal note pitches while the song plays'}
+      style={{
+        fontSize: 10, padding: '1px 5px', border: 'none', borderRadius: 3,
+        cursor: 'pointer', lineHeight: 1.4,
+        backgroundColor: enabled ? '#E879F9' : 'rgba(255,255,255,0.15)',
+        color: enabled ? '#000' : '#ccc',
+        boxShadow: enabled ? '0 0 6px #E879F980' : 'none'
+      }}
+      onClick={toggle}
+    >
+      🔊{showLabel ? ' Pitch' : ''}
+    </button>
+  )
+}

--- a/src/renderer/src/components/chartPreviewModules/UIOverlays.tsx
+++ b/src/renderer/src/components/chartPreviewModules/UIOverlays.tsx
@@ -5,6 +5,7 @@ import type { Instrument, Difficulty, NoteModifiers, VocalNote, VocalPhrase, Har
 import type { EditingTool } from './types'
 import { getAudioSources, onAudioLoaded, playPitchPreview, stopPitchPreview, seek as seekAudio } from '../../services/audioService'
 import { resolveVenuePlaybackState } from './venuePlayback'
+import { VocalPitchPlaybackToggle } from '../VocalPitchPlaybackToggle'
 
 function formatVenueLabel(value: string): string {
   return value
@@ -961,6 +962,8 @@ export function VocalTrackOverlay({ songId }: { songId: string }): React.JSX.Ele
             ))}
           </span>
         )}
+        {/* Hear charted pitches during playback (issues #10, #58) */}
+        <VocalPitchPlaybackToggle showLabel />
       </div>
       <div
         ref={contentRef}


### PR DESCRIPTION
## Summary

Fixes #58. The vocal listen-in feature already exists (issue #10, shipped in v1.0.25): with the toggle on, each charted vocal note of the active harmony part sounds as a sine tone while the song plays. But the only control was an unlabeled 🔊 button buried in the MIDI editor's vocal pitch header, so charters working in the chart preview — where the issue's screenshot was taken — could not find it.

## Changes

- Extract `VocalPitchPlaybackToggle` into a shared component.
- Show it, labeled "🔊 Pitch", in the chart preview's vocal track overlay next to the harmony part selector.
- MIDI editor keeps its compact 🔊 variant, now via the shared component.

## Validation

- `npm test` — 109 tests passed
- `npm run typecheck`
- Playwright check against the built app: the toggle renders in the vocals overlay strip, and clicking it flips `vocalPitchPlayback` (tooltip switches to "Pitch playback on").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
