### PR TITLE
Release: auto-refresh yt-dlp to fix YouTube 403 downloads

### DIFF
--- a/docs/troubleshooting/auto-chart-issues.md
+++ b/docs/troubleshooting/auto-chart-issues.md
@@ -31,6 +31,7 @@ Demucs needs ~4 GB of free RAM for stem separation. If your machine doesn't have
 ## YouTube URL fails
 
 `yt-dlp` rejects the URL. Common causes:
+- **`HTTP Error 403: Forbidden` / `unable to download video data`** — YouTube changed something on their end and the installed `yt-dlp` is out of date. OCTAVE upgrades `yt-dlp` inside its Python runtime automatically (a throttled check before every URL run, plus a forced refresh-and-retry when a download is rejected), so usually just running the job again is enough. If it still fails right after an update, upstream `yt-dlp` hasn't caught up with YouTube yet — wait a day and retry, or download the audio yourself and pass the file in. The auto-refresh can be disabled with the `OCTAVE_YTDLP_AUTO_REFRESH=0` environment variable.
 - Age-restricted or region-locked video — try downloading the audio yourself and passing the file in.
 - `yt-dlp` cache out of date — delete `<user-data>/python-runtime/yt-dlp-cache/`.
 - No internet (offline mode is on but you didn't pre-download the audio).

--- a/resources/strum/strum_worker.py
+++ b/resources/strum/strum_worker.py
@@ -1711,13 +1711,39 @@ def download_youtube_audio(url: str, target_dir: Path, run_id: str) -> Path:
             percent = int((downloaded / total) * 100) if total else None
             emit_progress(run_id, "download", f"Downloading media URL: {url}", percent=percent, current_item=url)
 
+    class _YtDlpLogger:
+        """Route yt-dlp warnings/errors into the OCTAVE run log.
+
+        With quiet=True yt-dlp would otherwise swallow diagnostics such as
+        "No supported JavaScript runtime could be found" or "... requires a PO
+        token", which are exactly what's needed to debug a failed download.
+        """
+
+        def debug(self, message: str) -> None:  # noqa: D401 - yt-dlp protocol
+            # yt-dlp routes its own info lines through debug() prefixed
+            # with "[debug] "; only surface the non-debug ones, and skip the
+            # per-chunk "[download]  12.3% ..." lines (the progress hook
+            # already reports those).
+            if message.startswith(("[debug] ", "[download] ")):
+                return
+            print(f"[yt-dlp] {message}", file=sys.stderr, flush=True)
+
+        def info(self, message: str) -> None:
+            print(f"[yt-dlp] {message}", file=sys.stderr, flush=True)
+
+        def warning(self, message: str) -> None:
+            emit_progress(run_id, "download", f"yt-dlp: {message}", current_item=url)
+
+        def error(self, message: str) -> None:
+            emit_progress(run_id, "download", f"yt-dlp: {message}", current_item=url)
+
     output_template = str(target_dir / "%(title).180B-%(id)s.%(ext)s")
     options = {
         "format": "bestaudio/best",
         "noplaylist": True,
         "outtmpl": output_template,
         "quiet": True,
-        "no_warnings": True,
+        "logger": _YtDlpLogger(),
         "progress_hooks": [hook],
         "postprocessors": [{
             "key": "FFmpegExtractAudio",
@@ -1725,8 +1751,25 @@ def download_youtube_audio(url: str, target_dir: Path, run_id: str) -> Path:
             "preferredquality": "192",
         }],
     }
-    with yt_dlp.YoutubeDL(options) as downloader:
-        downloader.extract_info(url, download=True)
+    try:
+        with yt_dlp.YoutubeDL(options) as downloader:
+            downloader.extract_info(url, download=True)
+    except Exception as exc:  # yt_dlp.utils.DownloadError and friends
+        detail = str(exc).strip()
+        version = getattr(getattr(yt_dlp, "version", None), "__version__", "unknown")
+        # Keep the raw yt-dlp text (e.g. "HTTP Error 403: Forbidden") intact:
+        # the OCTAVE runner pattern-matches it to decide whether to refresh
+        # yt-dlp and retry the run.
+        if re.search(r"HTTP Error 403|403: Forbidden|unable to download video data", detail, re.IGNORECASE):
+            hint = (
+                "YouTube rejected the request, which usually means YouTube changed something "
+                "and yt-dlp needs an update. OCTAVE refreshes yt-dlp automatically and retries; "
+                "if it keeps failing, upstream yt-dlp has not caught up yet - try again later, "
+                "or download the audio yourself and pass the file in."
+            )
+        else:
+            hint = "If the video is private, age-restricted or region-locked, download the audio yourself and pass the file in."
+        raise IntegrationError(f"yt-dlp {version} could not download {url}: {detail} {hint}") from exc
 
     after = [entry.resolve() for entry in target_dir.iterdir() if entry.resolve() not in before and entry.is_file()]
     for candidate in sorted(after, key=lambda path: path.stat().st_mtime, reverse=True):

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import icon from '../../resources/icon.png?asset'
 import ffmpeg from 'fluent-ffmpeg'
 import { cancelAutoChart, getStrumRequirementsPath, killAllRunningJobs, openStrumLogsFolder, resolvePythonCommand, runAutoChart } from './strumIntegration/runner'
 import { ensureBootstrappedPython, getRuntimeStatus, isBootstrapTarget } from './strumIntegration/runtimeBootstrap'
+import { ensureFreshYtDlp, isYtDlpBlockedError } from './strumIntegration/ytDlpRefresh'
 import { packSng } from './sngPacker'
 import { packRb3con } from './conPacker'
 import { importSng } from './import/sngImporter'
@@ -1600,7 +1601,12 @@ ipcMain.handle('video:download-url', async (event, songPath: string, url: string
   }
   const args = [...pythonCmd.baseArgs, '-m', 'yt_dlp', ...ytDlpArgs]
 
-  return new Promise<{ success: boolean; filePath?: string; error?: string }>((resolvePromise) => {
+  // YouTube breaks stale yt-dlp builds every few weeks (HTTP 403 on the
+  // media URL). Do a throttled in-place upgrade first, and if the download is
+  // still rejected, force a refresh and retry once with the newer build.
+  await ensureFreshYtDlp(pythonCmd)
+
+  const attemptDownload = (): Promise<{ success: boolean; filePath?: string; error?: string }> => new Promise((resolvePromise) => {
     console.log('[yt-dlp] Starting download:', url)
     const proc = execFile(pythonCmd.command, args, { maxBuffer: 10 * 1024 * 1024 }, (error, stdout, stderr) => {
       if (error) {
@@ -1668,6 +1674,24 @@ ipcMain.handle('video:download-url', async (event, songPath: string, url: string
       })
     }
   })
+
+  let result = await attemptDownload()
+  if (!result.success && result.error && isYtDlpBlockedError(result.error)) {
+    const refresh = await ensureFreshYtDlp(pythonCmd, { force: true })
+    if (refresh.changed) {
+      console.log(`[yt-dlp] Download rejected; retrying with yt-dlp ${refresh.version}`)
+      event.sender.send('video:download-progress', 0)
+      result = await attemptDownload()
+    } else {
+      const versionNote = refresh.version ? ` (yt-dlp ${refresh.version})` : ''
+      result = {
+        ...result,
+        error: `${result.error}\n\nyt-dlp is already the newest available build${versionNote}. `
+          + 'YouTube may have changed something upstream has not fixed yet — try again later.'
+      }
+    }
+  }
+  return result
 })
 
 // Get audio waveform data - returns peak amplitude samples for visualization

--- a/src/main/strumIntegration/runner.ts
+++ b/src/main/strumIntegration/runner.ts
@@ -8,6 +8,7 @@ import { ensureBootstrappedPython, isBootstrapTarget } from './runtimeBootstrap'
 import { ensureDemucsCpp } from './demucsCppBootstrap'
 import { ensureWhisperCpp } from './whisperCppBootstrap'
 import { detectAccelerator } from './runtimeBootstrap'
+import { ensureFreshYtDlp, isYtDlpBlockedError } from './ytDlpRefresh'
 import type { AutoChartProgressEvent, AutoChartRunOptions, AutoChartRunResult, AutoChartStage } from './types'
 
 const EVENT_PREFIX = '__OCTAVE_EVENT__'
@@ -309,7 +310,8 @@ function normalizeGlobalPercent(stage: AutoChartStage, stagePercent: number): nu
 function handleStructuredEvent(
   line: string,
   completion: { result?: AutoChartRunResult; error?: string },
-  onProgress?: (event: AutoChartProgressEvent) => void
+  onProgress?: (event: AutoChartProgressEvent) => void,
+  suppressErrorBroadcast?: (message: string) => boolean
 ): boolean {
   if (!line.startsWith(EVENT_PREFIX)) {
     return false
@@ -367,7 +369,13 @@ function handleStructuredEvent(
 
     if (kind === 'error') {
       completion.error = String(payload.message ?? 'STRUM worker failed.')
-      broadcast('strum:error', payload)
+      // The caller may want to retry (e.g. after refreshing yt-dlp) — in that
+      // case hold the error back so the renderer doesn't flip into its
+      // terminal error state; runAutoChart's rejection path still surfaces it
+      // if the retry doesn't happen or also fails.
+      if (!suppressErrorBroadcast?.(completion.error)) {
+        broadcast('strum:error', payload)
+      }
       return true
     }
   } catch {
@@ -384,7 +392,68 @@ function handlePlainLine(runId: string, line: string): void {
   }
 }
 
+function isRemoteUrl(value: unknown): boolean {
+  return typeof value === 'string' && /^https?:\/\//i.test(value.trim())
+}
+
+/**
+ * True when the run will download something with yt-dlp (URL inputs, or
+ * stem-song entries whose stems/extras are URLs).
+ */
+function hasRemoteInputs(options: Omit<AutoChartRunOptions, 'cacheDir'>): boolean {
+  if ((options.urls ?? []).some(isRemoteUrl)) return true
+  for (const song of options.stemSongs ?? []) {
+    if (Object.values(song.stems ?? {}).some(isRemoteUrl)) return true
+    if ((song.extras ?? []).some(isRemoteUrl)) return true
+  }
+  return false
+}
+
 export async function runAutoChart(options: Omit<AutoChartRunOptions, 'cacheDir'>): Promise<AutoChartRunResult> {
+  const remote = hasRemoteInputs(options)
+  try {
+    return await runAutoChartOnce(options, { allowYtDlpRetry: remote, refreshYtDlp: remote })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (!remote || !isYtDlpBlockedError(message)) throw error
+
+    // YouTube rejected the download. Nine times out of ten this means YouTube
+    // changed something and the installed yt-dlp is stale — force a refresh
+    // and, if that produced a newer build, run again. Downloads happen at the
+    // very start of a run, so nothing expensive is lost by retrying.
+    const runId = options.runId
+    warnStrum(runId, `yt-dlp download was rejected (${message.split('\n')[0]}); refreshing yt-dlp and retrying.`)
+    const python = await findPythonCommand(runId)
+    const refresh = await ensureFreshYtDlp(python, {
+      runId,
+      // The renderer is already showing the 'download' stage; lower-ranked
+      // ('bootstrap') events would be dropped.
+      stage: 'download',
+      force: true,
+      reason: 'YouTube rejected the download; checking for a yt-dlp update...'
+    })
+    if (!refresh.changed) {
+      const versionNote = refresh.version ? ` (yt-dlp ${refresh.version})` : ''
+      throw new Error(
+        `${message}\n\nyt-dlp is already the newest available build${versionNote}. `
+        + 'YouTube may have changed something upstream has not fixed yet — try again later, '
+        + 'or download the audio yourself and pass the file in.'
+      )
+    }
+    broadcast('strum:progress', {
+      runId,
+      stage: 'download',
+      message: `yt-dlp updated to ${refresh.version} — retrying download...`
+    } satisfies AutoChartProgressEvent)
+    // yt-dlp was just refreshed; don't run the throttled check again.
+    return await runAutoChartOnce(options, { allowYtDlpRetry: false, refreshYtDlp: false })
+  }
+}
+
+async function runAutoChartOnce(
+  options: Omit<AutoChartRunOptions, 'cacheDir'>,
+  { allowYtDlpRetry, refreshYtDlp }: { allowYtDlpRetry: boolean; refreshYtDlp: boolean }
+): Promise<AutoChartRunResult> {
   const python = await findPythonCommand(options.runId)
   const runId = options.runId
   const cacheDir = join(app.getPath('userData'), 'cache', 'strum')
@@ -409,6 +478,13 @@ export async function runAutoChart(options: Omit<AutoChartRunOptions, 'cacheDir'
     message: 'Starting STRUM auto-chart run...',
     percent: 0
   } satisfies AutoChartProgressEvent)
+
+  // URL inputs go through yt-dlp, which YouTube breaks every few weeks. Do a
+  // (throttled) in-place upgrade before spawning the worker so users get the
+  // current build without a full runtime re-provision. Never fatal.
+  if (refreshYtDlp) {
+    await ensureFreshYtDlp(python, { runId })
+  }
 
   // Best-effort: provision demucs.cpp before spawning the worker so the
   // separate_stems step uses the native binary instead of the Python
@@ -519,6 +595,9 @@ export async function runAutoChart(options: Omit<AutoChartRunOptions, 'cacheDir'
     let stdoutRemainder = ''
     let stderrRemainder = ''
     const completion: { result?: AutoChartRunResult; error?: string } = {}
+    // Hold back the worker's own error broadcast when runAutoChart may still
+    // refresh yt-dlp and retry; the final rejection path re-broadcasts it.
+    const suppressYtDlpError = (message: string): boolean => allowYtDlpRetry && isYtDlpBlockedError(message)
     let lastOutputAt = Date.now()
     let lastProgressPercent = 0
     let lastProgressStage: AutoChartStage = 'bootstrap'
@@ -588,7 +667,7 @@ export async function runAutoChart(options: Omit<AutoChartRunOptions, 'cacheDir'
           if (typeof event.percent === 'number') {
             lastProgressPercent = Math.max(lastProgressPercent, event.percent)
           }
-        })) {
+        }, suppressYtDlpError)) {
           // Check if it's a tqdm progress line (e.g. " 10%|██      |")
           const tqdmMatch = line.match(/(\d+)%\|/)
           if (tqdmMatch) {
@@ -666,13 +745,13 @@ export async function runAutoChart(options: Omit<AutoChartRunOptions, 'cacheDir'
         if (verboseDebug) {
           logStrum(runId, `stdout(remainder)> ${stdoutRemainder}`)
         }
-        handleStructuredEvent(stdoutRemainder, completion) || handlePlainLine(runId, stdoutRemainder)
+        handleStructuredEvent(stdoutRemainder, completion, undefined, suppressYtDlpError) || handlePlainLine(runId, stdoutRemainder)
       }
       if (stderrRemainder) {
         if (verboseDebug) {
           logStrum(runId, `stderr(remainder)> ${stderrRemainder}`)
         }
-        handleStructuredEvent(stderrRemainder, completion) || handlePlainLine(runId, stderrRemainder)
+        handleStructuredEvent(stderrRemainder, completion, undefined, suppressYtDlpError) || handlePlainLine(runId, stderrRemainder)
       }
 
       if (signal === 'SIGTERM') {

--- a/src/main/strumIntegration/runner.ytdlpRetry.test.ts
+++ b/src/main/strumIntegration/runner.ytdlpRetry.test.ts
@@ -1,0 +1,230 @@
+// Exercises runAutoChart's "YouTube rejected the download → refresh yt-dlp →
+// retry once" orchestration with a fake worker process.
+import { EventEmitter } from 'node:events'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const scratch = mkdtempSync(join(tmpdir(), 'octave-runner-test-'))
+const sent: Array<{ channel: string; payload: unknown }> = []
+
+vi.mock('electron', () => ({
+  app: { getPath: () => scratch, isPackaged: false },
+  BrowserWindow: {
+    getAllWindows: () => [
+      {
+        webContents: {
+          send: (channel: string, payload: unknown) => sent.push({ channel, payload })
+        }
+      }
+    ]
+  },
+  shell: { openPath: async () => '' }
+}))
+
+vi.mock('./runtimeBootstrap', () => ({
+  ensureBootstrappedPython: async () => 'unused',
+  isBootstrapTarget: () => false,
+  detectAccelerator: () => 'cpu',
+  getRuntimeRoot: () => scratch
+}))
+vi.mock('./demucsCppBootstrap', () => ({
+  ensureDemucsCpp: async () => {
+    throw new Error('no demucs.cpp in test')
+  }
+}))
+vi.mock('./whisperCppBootstrap', () => ({
+  ensureWhisperCpp: async () => {
+    throw new Error('no whisper.cpp in test')
+  }
+}))
+
+const refreshMock = vi.fn()
+vi.mock('./ytDlpRefresh', async () => {
+  const actual = await vi.importActual<typeof import('./ytDlpRefresh')>('./ytDlpRefresh')
+  return { ...actual, ensureFreshYtDlp: (...args: unknown[]) => refreshMock(...args) }
+})
+
+// Fake worker: each spawn() pops the next scripted outcome.
+type Outcome = { errorMessage: string } | { success: true }
+const outcomes: Outcome[] = []
+const spawnCalls: string[][] = []
+
+class FakeChild extends EventEmitter {
+  pid = 4242
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+  kill(): boolean {
+    return true
+  }
+}
+
+vi.mock('child_process', () => ({
+  execFile: (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null) => void) => {
+    // findPythonCommand probes candidates with `--version`; accept the first.
+    cb(null)
+  },
+  spawn: (_cmd: string, args: string[]) => {
+    spawnCalls.push(args)
+    const child = new FakeChild()
+    const outcome = outcomes.shift()
+    setTimeout(() => {
+      if (!outcome) {
+        child.emit('close', 1, null)
+        return
+      }
+      if ('errorMessage' in outcome) {
+        child.stdout.emit(
+          'data',
+          Buffer.from(
+            `__OCTAVE_EVENT__${JSON.stringify({ kind: 'error', runId: 'run-1', message: outcome.errorMessage })}\n`
+          )
+        )
+        child.emit('close', 1, null)
+      } else {
+        child.stdout.emit(
+          'data',
+          Buffer.from(
+            `__OCTAVE_EVENT__${JSON.stringify({ kind: 'complete', runId: 'run-1', success: true, outputDir: scratch, songFolders: [], errors: [] })}\n`
+          )
+        )
+        child.emit('close', 0, null)
+      }
+    }, 5)
+    return child
+  }
+}))
+
+import { runAutoChart } from './runner'
+
+const YT_403 =
+  'yt-dlp 2026.03.17 could not download https://youtu.be/x: ERROR: unable to download video data: HTTP Error 403: Forbidden'
+
+const baseOptions = {
+  runId: 'run-1',
+  outputDir: scratch,
+  files: [] as string[],
+  folders: [] as string[],
+  stemFolders: [] as string[],
+  urls: ['https://youtu.be/x']
+}
+
+beforeEach(() => {
+  sent.length = 0
+  outcomes.length = 0
+  spawnCalls.length = 0
+  refreshMock.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('runAutoChart yt-dlp refresh + retry', () => {
+  it('refreshes before a URL run, and retries once after a 403 when the refresh produced a newer build', async () => {
+    refreshMock
+      // proactive (throttled) check before the run
+      .mockResolvedValueOnce({
+        attempted: false,
+        succeeded: false,
+        changed: false,
+        version: '2026.3.17',
+        previousVersion: '2026.3.17'
+      })
+      // forced refresh after the 403
+      .mockResolvedValueOnce({
+        attempted: true,
+        succeeded: true,
+        changed: true,
+        version: '2026.8.18.dev0',
+        previousVersion: '2026.3.17'
+      })
+    outcomes.push({ errorMessage: YT_403 }, { success: true })
+
+    const result = await runAutoChart(baseOptions)
+
+    expect(result.success).toBe(true)
+    expect(spawnCalls).toHaveLength(2)
+    expect(refreshMock).toHaveBeenCalledTimes(2)
+    expect(refreshMock.mock.calls[0][1]).toMatchObject({ runId: 'run-1' })
+    expect(refreshMock.mock.calls[1][1]).toMatchObject({ runId: 'run-1', force: true })
+
+    // The first attempt's worker error must NOT reach the renderer as a
+    // terminal strum:error (it would lock the modal into its error state).
+    expect(sent.filter((e) => e.channel === 'strum:error')).toHaveLength(0)
+    const messages = sent
+      .filter((e) => e.channel === 'strum:progress')
+      .map((e) => (e.payload as { message: string }).message)
+    expect(messages.some((m) => /yt-dlp updated to 2026\.8\.18\.dev0/.test(m))).toBe(true)
+  })
+
+  it('does not retry when the refresh found nothing newer, and explains why', async () => {
+    refreshMock
+      .mockResolvedValueOnce({
+        attempted: false,
+        succeeded: false,
+        changed: false,
+        version: '2026.8.18.dev0',
+        previousVersion: '2026.8.18.dev0'
+      })
+      .mockResolvedValueOnce({
+        attempted: true,
+        succeeded: true,
+        changed: false,
+        version: '2026.8.18.dev0',
+        previousVersion: '2026.8.18.dev0'
+      })
+    outcomes.push({ errorMessage: YT_403 })
+
+    await expect(runAutoChart(baseOptions)).rejects.toThrow(
+      /HTTP Error 403[\s\S]*already the newest available build \(yt-dlp 2026\.8\.18\.dev0\)/
+    )
+    expect(spawnCalls).toHaveLength(1)
+    expect(refreshMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not touch yt-dlp for runs without remote inputs', async () => {
+    outcomes.push({ errorMessage: 'FFmpeg was not found on PATH.' })
+
+    await expect(runAutoChart({ ...baseOptions, urls: [] })).rejects.toThrow(/FFmpeg was not found/)
+    expect(refreshMock).not.toHaveBeenCalled()
+    expect(spawnCalls).toHaveLength(1)
+    // Non-yt-dlp errors are broadcast immediately as before.
+    expect(sent.filter((e) => e.channel === 'strum:error')).toHaveLength(1)
+  })
+
+  it('does not retry non-yt-dlp failures on URL runs', async () => {
+    refreshMock.mockResolvedValue({
+      attempted: false,
+      succeeded: false,
+      changed: false,
+      version: null,
+      previousVersion: null
+    })
+    outcomes.push({ errorMessage: 'STRUM auto-chart run was cancelled.' })
+
+    await expect(runAutoChart(baseOptions)).rejects.toThrow(/cancelled/)
+    expect(spawnCalls).toHaveLength(1)
+    expect(refreshMock).toHaveBeenCalledTimes(1)
+    expect(sent.filter((e) => e.channel === 'strum:error')).toHaveLength(1)
+  })
+
+  it('treats URL stems in stem-song entries as remote inputs', async () => {
+    refreshMock.mockResolvedValue({
+      attempted: false,
+      succeeded: false,
+      changed: false,
+      version: null,
+      previousVersion: null
+    })
+    outcomes.push({ success: true })
+
+    await runAutoChart({
+      ...baseOptions,
+      urls: [],
+      stemSongs: [{ name: 'x', stems: { drums: 'https://youtu.be/d' } }]
+    })
+    expect(refreshMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/strumIntegration/runtimeBootstrap.ts
+++ b/src/main/strumIntegration/runtimeBootstrap.ts
@@ -123,7 +123,7 @@ function emitProgress(runId: string | undefined, message: string, percent?: numb
   console.log(`[BOOTSTRAP] ${message}`)
 }
 
-function getRuntimeRoot(): string {
+export function getRuntimeRoot(): string {
   return join(app.getPath('userData'), 'python-runtime')
 }
 

--- a/src/main/strumIntegration/ytDlpRefresh.test.ts
+++ b/src/main/strumIntegration/ytDlpRefresh.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '', isPackaged: false },
+  BrowserWindow: { getAllWindows: () => [] }
+}))
+
+import { isManagedPython, isYtDlpBlockedError } from './ytDlpRefresh'
+
+describe('isYtDlpBlockedError', () => {
+  it('matches the YouTube 403 error as surfaced by the STRUM worker', () => {
+    expect(
+      isYtDlpBlockedError(
+        'Unhandled STRUM worker error: ERROR: unable to download video data: HTTP Error 403: Forbidden'
+      )
+    ).toBe(true)
+  })
+
+  it('matches the yt-dlp CLI failure text returned by execFile', () => {
+    expect(
+      isYtDlpBlockedError(
+        'Command failed: python -m yt_dlp ...\nERROR: unable to download video data: HTTP Error 403: Forbidden'
+      )
+    ).toBe(true)
+  })
+
+  it('matches missing-format and signature failures', () => {
+    expect(isYtDlpBlockedError('ERROR: [youtube] abc: Requested format is not available')).toBe(
+      true
+    )
+    expect(isYtDlpBlockedError('WARNING: [youtube] abc: nsig extraction failed')).toBe(true)
+  })
+
+  it('ignores unrelated failures so they are not retried', () => {
+    expect(isYtDlpBlockedError('STRUM auto-chart run was cancelled.')).toBe(false)
+    expect(isYtDlpBlockedError('FFmpeg was not found on PATH.')).toBe(false)
+    expect(isYtDlpBlockedError('ERROR: [youtube] abc: Video unavailable')).toBe(false)
+    expect(isYtDlpBlockedError('HTTP Error 404: Not Found')).toBe(false)
+  })
+})
+
+describe('isManagedPython', () => {
+  const originalEnv = process.env.OCTAVE_YTDLP_AUTO_REFRESH
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.OCTAVE_YTDLP_AUTO_REFRESH
+    else process.env.OCTAVE_YTDLP_AUTO_REFRESH = originalEnv
+  })
+
+  it('allows a workspace-local .venv in dev', () => {
+    delete process.env.OCTAVE_YTDLP_AUTO_REFRESH
+    expect(isManagedPython({ command: 'F:\\repo\\.venv\\Scripts\\python.exe', baseArgs: [] })).toBe(
+      true
+    )
+    expect(isManagedPython({ command: '/repo/.venv/bin/python', baseArgs: [] })).toBe(true)
+  })
+
+  it('refuses system interpreters in dev', () => {
+    delete process.env.OCTAVE_YTDLP_AUTO_REFRESH
+    expect(isManagedPython({ command: 'py', baseArgs: ['-3.11'] })).toBe(false)
+    expect(isManagedPython({ command: 'python3', baseArgs: [] })).toBe(false)
+  })
+
+  it('can be disabled via OCTAVE_YTDLP_AUTO_REFRESH=0', () => {
+    process.env.OCTAVE_YTDLP_AUTO_REFRESH = '0'
+    expect(isManagedPython({ command: '/repo/.venv/bin/python', baseArgs: [] })).toBe(false)
+  })
+})

--- a/src/main/strumIntegration/ytDlpRefresh.ts
+++ b/src/main/strumIntegration/ytDlpRefresh.ts
@@ -1,0 +1,371 @@
+// Keeps yt-dlp fresh inside the bootstrapped Python runtime.
+//
+// YouTube changes its player / streaming clients every few weeks and each
+// change breaks whichever yt-dlp release is pinned in requirements.txt
+// (typical symptom: `ERROR: unable to download video data: HTTP Error 403:
+// Forbidden`). Re-pinning requirements.txt would force every user through a
+// full runtime re-provision (~700 MB), so instead we upgrade yt-dlp in place
+// with pip:
+//
+//   * at most once a day before any auto-chart run / video download that
+//     involves a remote URL, and
+//   * immediately (forced) when a download fails with a 403-class error, so
+//     the caller can retry with the fixed build.
+//
+// yt-dlp's `nightly` channel is the project's recommended channel for regular
+// users and is published to PyPI as dev releases; the `.dev0` marker in the
+// requirement specifier lets pip pick those for yt-dlp only (deps still
+// resolve to stable). `[default]` pulls the yt-dlp-ejs challenge-solver
+// scripts and `[deno]` a pip-packaged deno binary, which yt-dlp discovers
+// automatically in the runtime's Scripts/bin dir. Without a JS runtime yt-dlp
+// falls back to a deprecated JS-less extraction path that YouTube keeps
+// shutting down.
+//
+// The pinned yt-dlp in requirements.txt is still what fresh runtimes start
+// with; this module only ever moves forward from there.
+
+import { app, BrowserWindow } from 'electron'
+import { execFile, spawn } from 'child_process'
+import { existsSync, readFileSync } from 'fs'
+import { mkdir, writeFile } from 'fs/promises'
+import { dirname, join } from 'path'
+import { getRuntimeRoot, isBootstrapTarget } from './runtimeBootstrap'
+import type { AutoChartProgressEvent, AutoChartStage } from './types'
+
+/**
+ * Preferred install spec: nightly-capable yt-dlp with the EJS solver scripts
+ * and a bundled deno runtime.
+ */
+export const YT_DLP_REQUIREMENT = 'yt-dlp[default,deno]>=2026.7.4.dev0'
+/**
+ * Fallback when the deno wheel is unavailable for this platform — yt-dlp
+ * itself still gets upgraded.
+ */
+const YT_DLP_REQUIREMENT_NO_DENO = 'yt-dlp[default]>=2026.7.4.dev0'
+
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
+const FAILURE_BACKOFF_MS = 60 * 60 * 1000
+const PIP_TIMEOUT_MS = 10 * 60 * 1000
+const VERSION_PROBE_TIMEOUT_MS = 30_000
+
+/**
+ * Error text patterns that mean "YouTube rejected yt-dlp's request", i.e. the
+ * installed yt-dlp is (probably) stale. Used by callers to decide whether a
+ * forced refresh + retry is worth attempting.
+ */
+const YT_DLP_BLOCKED_PATTERNS = [
+  /HTTP Error 403/i,
+  /403:? Forbidden/i,
+  /unable to download video data/i,
+  /Requested format is not available/i,
+  /nsig extraction failed|Signature extraction failed/i,
+  /Only images are available for download/i
+]
+
+export function isYtDlpBlockedError(message: string): boolean {
+  return YT_DLP_BLOCKED_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+export type PythonInvocation = {
+  command: string
+  baseArgs: string[]
+}
+
+export type YtDlpRefreshResult = {
+  /** True when pip actually ran (not skipped by the daily throttle). */
+  attempted: boolean
+  /** True when pip ran and exited successfully. */
+  succeeded: boolean
+  /** True when the installed yt-dlp version differs from before the refresh. */
+  changed: boolean
+  /** yt-dlp version installed after the refresh (or currently, when skipped). */
+  version: string | null
+  /** yt-dlp version installed before the refresh. */
+  previousVersion: string | null
+  /** Human-readable reason when the refresh was skipped or failed. */
+  note?: string
+}
+
+type RefreshState = {
+  requirement: string
+  lastAttemptAt: string
+  lastSuccessAt?: string
+  version?: string
+  lastError?: string
+}
+
+function stateFilePath(): string {
+  const dir = isBootstrapTarget() ? getRuntimeRoot() : app.getPath('userData')
+  return join(dir, '.octave-ytdlp-refresh.json')
+}
+
+function readState(): RefreshState | null {
+  try {
+    return JSON.parse(readFileSync(stateFilePath(), 'utf-8')) as RefreshState
+  } catch {
+    return null
+  }
+}
+
+async function writeState(state: RefreshState): Promise<void> {
+  const path = stateFilePath()
+  try {
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, JSON.stringify(state, null, 2), 'utf-8')
+  } catch (err) {
+    console.warn(
+      `[yt-dlp] failed to persist refresh state: ${err instanceof Error ? err.message : String(err)}`
+    )
+  }
+}
+
+type ProgressSink = {
+  runId?: string
+  /**
+   * Stage to tag progress events with. The renderer drops events whose stage
+   * ranks below the one it is currently showing, so a forced refresh in the
+   * middle of a run should use that run's current stage (e.g. 'download').
+   */
+  stage?: AutoChartStage
+}
+
+function broadcastProgress(sink: ProgressSink, message: string): void {
+  if (!sink.runId) return
+  const event: AutoChartProgressEvent = {
+    runId: sink.runId,
+    stage: sink.stage ?? 'bootstrap',
+    message
+  }
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send('strum:progress', event)
+  }
+}
+
+/**
+ * Whether we're allowed to pip-install into this interpreter. Always true for
+ * the userData runtime we provision ourselves; in dev only for a
+ * workspace-local `.venv` (never a system / `py` launcher interpreter).
+ * `OCTAVE_YTDLP_AUTO_REFRESH=0` disables the mechanism entirely.
+ */
+export function isManagedPython(python: PythonInvocation): boolean {
+  if (process.env.OCTAVE_YTDLP_AUTO_REFRESH === '0') return false
+  if (isBootstrapTarget()) return true
+  return /[\\/]\.venv[\\/]/.test(python.command)
+}
+
+function probeVersion(python: PythonInvocation): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      python.command,
+      [...python.baseArgs, '-c', "import importlib.metadata as m; print(m.version('yt-dlp'))"],
+      { timeout: VERSION_PROBE_TIMEOUT_MS, env: { ...process.env, PYTHONUTF8: '1' } },
+      (error, stdout) => {
+        if (error) {
+          resolve(null)
+          return
+        }
+        const version = stdout.trim().split(/\r?\n/).pop()?.trim() ?? ''
+        resolve(version || null)
+      }
+    )
+  })
+}
+
+function runPip(
+  python: PythonInvocation,
+  requirement: string,
+  sink: ProgressSink
+): Promise<{ ok: boolean; tail: string }> {
+  return new Promise((resolve) => {
+    const args = [
+      ...python.baseArgs,
+      '-m',
+      'pip',
+      'install',
+      '--upgrade',
+      '--prefer-binary',
+      '--disable-pip-version-check',
+      '--no-input',
+      '--timeout',
+      '30',
+      '--retries',
+      '2',
+      requirement
+    ]
+    console.log(`[yt-dlp] refreshing: ${python.command} ${args.join(' ')}`)
+    const child = spawn(python.command, args, {
+      env: { ...process.env, PIP_DISABLE_PIP_VERSION_CHECK: '1', PYTHONUTF8: '1' },
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+
+    const tail: string[] = []
+    let settled = false
+    const finish = (ok: boolean): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve({ ok, tail: tail.slice(-20).join('\n') })
+    }
+    const timer = setTimeout(() => {
+      console.warn('[yt-dlp] pip refresh timed out; killing.')
+      try {
+        child.kill()
+      } catch {
+        /* noop */
+      }
+      tail.push('pip refresh timed out')
+      finish(false)
+    }, PIP_TIMEOUT_MS)
+
+    let lastBroadcast = 0
+    const onChunk = (chunk: Buffer): void => {
+      for (const raw of chunk.toString('utf-8').split(/\r?\n/)) {
+        const line = raw.replace(/\r/g, '').trim()
+        if (!line) continue
+        tail.push(line)
+        if (tail.length > 60) tail.shift()
+        const now = Date.now()
+        if (sink.runId && now - lastBroadcast > 1000) {
+          broadcastProgress(sink, `Updating yt-dlp: ${line.slice(0, 160)}`)
+          lastBroadcast = now
+        }
+      }
+    }
+    child.stdout?.on('data', onChunk)
+    child.stderr?.on('data', onChunk)
+    child.on('error', (err) => {
+      tail.push(err.message)
+      finish(false)
+    })
+    child.on('close', (code) => finish(code === 0))
+  })
+}
+
+const inflight = new Map<string, Promise<YtDlpRefreshResult>>()
+
+/**
+ * Upgrade yt-dlp inside `python` if it hasn't been checked in the last 24h
+ * (or unconditionally when `force` is set). Never throws — a failed refresh
+ * just leaves the currently installed build in place and reports `succeeded:
+ * false`, so callers can proceed with the download attempt regardless.
+ */
+export async function ensureFreshYtDlp(
+  python: PythonInvocation,
+  opts: { runId?: string; stage?: AutoChartStage; force?: boolean; reason?: string } = {}
+): Promise<YtDlpRefreshResult> {
+  const key = `${python.command} ${python.baseArgs.join(' ')}`
+  const pending = inflight.get(key)
+  if (pending) return pending
+
+  const task = (async (): Promise<YtDlpRefreshResult> => {
+    if (!isManagedPython(python)) {
+      return {
+        attempted: false,
+        succeeded: false,
+        changed: false,
+        version: null,
+        previousVersion: null,
+        note: 'yt-dlp auto-refresh is only applied to the OCTAVE-managed Python runtime.'
+      }
+    }
+    if (!existsSync(python.command)) {
+      return {
+        attempted: false,
+        succeeded: false,
+        changed: false,
+        version: null,
+        previousVersion: null,
+        note: 'Python runtime not found.'
+      }
+    }
+
+    const state = readState()
+    const now = Date.now()
+    if (!opts.force && state && state.requirement === YT_DLP_REQUIREMENT) {
+      const lastSuccess = state.lastSuccessAt ? Date.parse(state.lastSuccessAt) : NaN
+      const lastAttempt = Date.parse(state.lastAttemptAt)
+      if (Number.isFinite(lastSuccess) && now - lastSuccess < CHECK_INTERVAL_MS) {
+        return {
+          attempted: false,
+          succeeded: false,
+          changed: false,
+          version: state.version ?? null,
+          previousVersion: state.version ?? null,
+          note: 'yt-dlp was checked for updates recently.'
+        }
+      }
+      if (
+        !Number.isFinite(lastSuccess) &&
+        Number.isFinite(lastAttempt) &&
+        now - lastAttempt < FAILURE_BACKOFF_MS
+      ) {
+        return {
+          attempted: false,
+          succeeded: false,
+          changed: false,
+          version: state.version ?? null,
+          previousVersion: state.version ?? null,
+          note: `Skipping yt-dlp update check after a recent failure (${state.lastError ?? 'unknown error'}).`
+        }
+      }
+    }
+
+    const previousVersion = await probeVersion(python)
+    const sink: ProgressSink = { runId: opts.runId, stage: opts.stage }
+    broadcastProgress(
+      sink,
+      opts.reason ??
+        `Checking for yt-dlp updates${previousVersion ? ` (installed: ${previousVersion})` : ''}...`
+    )
+    console.log(
+      `[yt-dlp] refresh start (installed=${previousVersion ?? 'unknown'}, force=${opts.force === true}${opts.reason ? `, reason=${opts.reason}` : ''})`
+    )
+
+    let result = await runPip(python, YT_DLP_REQUIREMENT, sink)
+    if (!result.ok) {
+      console.warn(`[yt-dlp] refresh with deno failed; retrying without deno.\n${result.tail}`)
+      result = await runPip(python, YT_DLP_REQUIREMENT_NO_DENO, sink)
+    }
+
+    const version = result.ok ? await probeVersion(python) : previousVersion
+    const nowIso = new Date().toISOString()
+    await writeState({
+      requirement: YT_DLP_REQUIREMENT,
+      lastAttemptAt: nowIso,
+      ...(result.ok ? { lastSuccessAt: nowIso } : { lastSuccessAt: state?.lastSuccessAt }),
+      version: version ?? undefined,
+      ...(result.ok ? {} : { lastError: result.tail.split('\n').pop() ?? 'pip failed' })
+    })
+
+    const changed = result.ok && !!version && version !== previousVersion
+    if (result.ok) {
+      const summary = changed
+        ? `yt-dlp updated ${previousVersion ?? '?'} → ${version}`
+        : `yt-dlp ${version ?? 'unknown'} is up to date`
+      console.log(`[yt-dlp] ${summary}`)
+      broadcastProgress(sink, `${summary}.`)
+    } else {
+      console.warn(
+        `[yt-dlp] refresh failed; keeping installed build ${previousVersion ?? 'unknown'}.\n${result.tail}`
+      )
+      broadcastProgress(
+        sink,
+        `Could not update yt-dlp (keeping ${previousVersion ?? 'installed build'}); continuing.`
+      )
+    }
+
+    return {
+      attempted: true,
+      succeeded: result.ok,
+      changed,
+      version,
+      previousVersion,
+      ...(result.ok ? {} : { note: result.tail.split('\n').slice(-3).join(' | ') })
+    }
+  })().finally(() => {
+    inflight.delete(key)
+  })
+
+  inflight.set(key, task)
+  return task
+}


### PR DESCRIPTION
## Summary

Promotes beta (`v1.0.27-beta.1`) to stable with one verified change:

- **043a154** — YouTube killed the `android_vr` adaptive streams (~2026-08-16), so every yt-dlp release through stable 2026.07.04 fails with `unable to download video data: HTTP Error 403: Forbidden` (yt-dlp/yt-dlp#17456); the fix is only in yt-dlp nightly. Rather than re-pin `requirements.txt` (which would force every user through a ~700 MB runtime re-provision and be stale again next month), OCTAVE now upgrades yt-dlp **in place** inside the bootstrapped runtime (`yt-dlp[default,deno]>=2026.7.4.dev0` — nightly-capable specifier, EJS solver scripts, pip-packaged deno JS runtime): a throttled daily check before any URL run / video download, plus a forced refresh-and-retry when a download is rejected. Worker errors are surfaced as clean `IntegrationError`s with guidance, and yt-dlp warnings are forwarded into the run log. `OCTAVE_YTDLP_AUTO_REFRESH=0` opts out. Fixes #62.

## Validation on beta

- Reproduced the 403 with the pinned 2026.3.17 **and** stable 2026.7.4; verified nightly + deno downloads succeed (audio-only worker config and the background-video format string).
- Ran the refresh against a real bootstrapped runtime: `2026.3.17 → 2026.8.18.122307.dev0` in ~12 s, throttle/force paths OK, pinned deps (requests/urllib3/certifi/torch) untouched, previously-403ing `download_youtube_audio` now succeeds.
- `npm test` — 17 files / 121 tests passed (12 new: blocked-error matcher, managed-python gating, runner refresh+retry orchestration with a fake worker)
- `npm run typecheck` clean; CI + Build & Release (Beta) green on `043a154`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
