### PR TITLE
fix: runtime install fails with 'spawn tar ENOENT' on Windows machines with a broken PATH

### DIFF
--- a/src/main/strumIntegration/demucsCppBootstrap.ts
+++ b/src/main/strumIntegration/demucsCppBootstrap.ts
@@ -14,13 +14,13 @@
 // than at app launch.
 
 import { app, BrowserWindow } from 'electron'
-import { execFile } from 'child_process'
 import { existsSync, readFileSync, createWriteStream } from 'fs'
 import { mkdir, rm, writeFile, chmod } from 'fs/promises'
 import { join } from 'path'
 import { pipeline } from 'stream/promises'
 import { Readable } from 'stream'
 import type { AutoChartProgressEvent } from './types'
+import { extractTarGz } from './extractTarGz'
 
 // Bump together with the binary release version. Each bump invalidates
 // the on-disk cache so users get the new binary on next launch.
@@ -172,16 +172,6 @@ async function downloadFile(
     }
   })
   await pipeline(nodeStream, out)
-}
-
-async function extractTarGz(archivePath: string, destDir: string): Promise<void> {
-  await mkdir(destDir, { recursive: true })
-  await new Promise<void>((resolve, reject) => {
-    execFile('tar', ['-xzf', archivePath, '-C', destDir], (err) => {
-      if (err) reject(err)
-      else resolve()
-    })
-  })
 }
 
 let inflight: Promise<{ binaryPath: string; weightsPath: string }> | null = null

--- a/src/main/strumIntegration/extractTarGz.test.ts
+++ b/src/main/strumIntegration/extractTarGz.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const execFileMock = vi.fn()
+const existsSyncMock = vi.fn()
+
+vi.mock('child_process', () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args)
+}))
+
+vi.mock('fs', () => ({
+  existsSync: (...args: unknown[]) => existsSyncMock(...args)
+}))
+
+vi.mock('fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined)
+}))
+
+import { extractTarGz, _resetTarCommandCacheForTests } from './extractTarGz'
+
+function completeWith(err: Error | null): void {
+  execFileMock.mockImplementation((_cmd, _args, cb) => {
+    ;(cb as (err: Error | null) => void)(err)
+  })
+}
+
+describe('extractTarGz', () => {
+  beforeEach(() => {
+    _resetTarCommandCacheForTests()
+    execFileMock.mockReset()
+    existsSyncMock.mockReset()
+  })
+
+  it('prefers the absolute System32 tar.exe on Windows (issue #65: broken PATH)', async () => {
+    if (process.platform !== 'win32') return
+    existsSyncMock.mockReturnValue(true)
+    completeWith(null)
+
+    await extractTarGz('C:\\a.tar.gz', 'C:\\dest')
+
+    const [command, args] = execFileMock.mock.calls[0]
+    expect(command).toMatch(/System32[\\/]tar\.exe$/i)
+    expect(args).toEqual(['-xzf', 'C:\\a.tar.gz', '-C', 'C:\\dest'])
+  })
+
+  it('falls back to PATH lookup when the bundled tar is missing', async () => {
+    existsSyncMock.mockReturnValue(false)
+    completeWith(null)
+
+    await extractTarGz('/a.tar.gz', '/dest')
+
+    expect(execFileMock.mock.calls[0][0]).toBe('tar')
+  })
+
+  it('rewrites spawn ENOENT into an actionable error message', async () => {
+    existsSyncMock.mockReturnValue(false)
+    const enoent = Object.assign(new Error('spawn tar ENOENT'), { code: 'ENOENT' })
+    completeWith(enoent)
+
+    await expect(extractTarGz('/a.tar.gz', '/dest')).rejects.toThrow(
+      /Could not find the "tar" utility/
+    )
+  })
+
+  it('passes through non-ENOENT tar failures unchanged', async () => {
+    existsSyncMock.mockReturnValue(false)
+    completeWith(new Error('tar: corrupted archive'))
+
+    await expect(extractTarGz('/a.tar.gz', '/dest')).rejects.toThrow('tar: corrupted archive')
+  })
+})

--- a/src/main/strumIntegration/extractTarGz.ts
+++ b/src/main/strumIntegration/extractTarGz.ts
@@ -1,0 +1,65 @@
+// Shared .tar.gz extraction for the bootstrap modules (Python runtime,
+// whisper.cpp, demucs.cpp).
+//
+// tar is built into Windows 10 1803+, macOS, and Linux, and `-xzf` works
+// identically across all three. However, spawning plain `tar` relies on the
+// user's PATH containing the right directory (System32 on Windows), and a
+// surprising number of Windows machines have a mangled PATH — which surfaces
+// as `spawn tar ENOENT` (issue #65). To be immune to that, prefer the
+// absolute path to the bundled Windows tar and only fall back to PATH lookup.
+
+import { execFile } from 'child_process'
+import { existsSync } from 'fs'
+import { mkdir } from 'fs/promises'
+import { join } from 'path'
+
+let cachedTarCommand: string | null = null
+
+function resolveTarCommand(): string {
+  if (cachedTarCommand) return cachedTarCommand
+  if (process.platform === 'win32') {
+    const systemRoot = process.env.SystemRoot || process.env.windir || 'C:\\Windows'
+    const systemTar = join(systemRoot, 'System32', 'tar.exe')
+    if (existsSync(systemTar)) {
+      cachedTarCommand = systemTar
+      return systemTar
+    }
+  }
+  cachedTarCommand = 'tar'
+  return cachedTarCommand
+}
+
+/** Extract a .tar.gz archive into destDir (created if missing). */
+export async function extractTarGz(archivePath: string, destDir: string): Promise<void> {
+  await mkdir(destDir, { recursive: true })
+  const tarCommand = resolveTarCommand()
+  await new Promise<void>((resolve, reject) => {
+    execFile(tarCommand, ['-xzf', archivePath, '-C', destDir], (err) => {
+      if (!err) {
+        resolve()
+        return
+      }
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        // tar itself could not be found — give the user something actionable
+        // instead of the cryptic "spawn tar ENOENT".
+        reject(
+          new Error(
+            process.platform === 'win32'
+              ? 'Could not find the "tar" utility needed to extract the downloaded archive. ' +
+                'It ships with Windows 10 (1803+) at C:\\Windows\\System32\\tar.exe. ' +
+                'Please verify that file exists, or reinstall the optional "tar" feature / update Windows, then try again.'
+              : 'Could not find the "tar" utility needed to extract the downloaded archive. ' +
+                'Please install tar via your system package manager and try again.'
+          )
+        )
+        return
+      }
+      reject(err)
+    })
+  })
+}
+
+/** Test-only: reset the cached tar command resolution. */
+export function _resetTarCommandCacheForTests(): void {
+  cachedTarCommand = null
+}

--- a/src/main/strumIntegration/runtimeBootstrap.ts
+++ b/src/main/strumIntegration/runtimeBootstrap.ts
@@ -18,7 +18,7 @@
 // setup from minutes to seconds. This module's public API stays the same.
 
 import { app, BrowserWindow } from 'electron'
-import { execFile, spawn } from 'child_process'
+import { spawn } from 'child_process'
 import { existsSync, readFileSync, createWriteStream } from 'fs'
 import { mkdir, rm, writeFile } from 'fs/promises'
 import { createHash } from 'crypto'
@@ -26,6 +26,7 @@ import { join } from 'path'
 import { pipeline } from 'stream/promises'
 import { Readable } from 'stream'
 import type { AutoChartProgressEvent } from './types'
+import { extractTarGz } from './extractTarGz'
 
 // Pinned python-build-standalone release. Bump in lockstep with
 // requirements.txt if the wheel set requires a newer Python.
@@ -248,18 +249,6 @@ async function downloadFile(url: string, destination: string, runId: string | un
     }
   })
   await pipeline(nodeStream, out)
-}
-
-async function extractTarGz(archivePath: string, destDir: string): Promise<void> {
-  await mkdir(destDir, { recursive: true })
-  // tar is built into Windows 10 1803+, macOS, and Linux. -xzf works
-  // identically across all three.
-  await new Promise<void>((resolve, reject) => {
-    execFile('tar', ['-xzf', archivePath, '-C', destDir], (err) => {
-      if (err) reject(err)
-      else resolve()
-    })
-  })
 }
 
 function runStreaming(

--- a/src/main/strumIntegration/whisperCppBootstrap.ts
+++ b/src/main/strumIntegration/whisperCppBootstrap.ts
@@ -15,13 +15,13 @@
 // users who never chart vocals.
 
 import { app, BrowserWindow } from 'electron'
-import { execFile } from 'child_process'
 import { existsSync, readFileSync, createWriteStream } from 'fs'
 import { mkdir, rm, writeFile, chmod } from 'fs/promises'
 import { join } from 'path'
 import { pipeline } from 'stream/promises'
 import { Readable } from 'stream'
 import type { AutoChartProgressEvent } from './types'
+import { extractTarGz } from './extractTarGz'
 import { detectAccelerator } from './runtimeBootstrap'
 
 // Bump together with the binary release version. Each bump invalidates
@@ -196,16 +196,6 @@ async function downloadFile(
     }
   })
   await pipeline(nodeStream, out)
-}
-
-async function extractTarGz(archivePath: string, destDir: string): Promise<void> {
-  await mkdir(destDir, { recursive: true })
-  await new Promise<void>((resolve, reject) => {
-    execFile('tar', ['-xzf', archivePath, '-C', destDir], (err) => {
-      if (err) reject(err)
-      else resolve()
-    })
-  })
 }
 
 let inflight: Promise<{ binaryPath: string; modelPath: string }> | null = null


### PR DESCRIPTION
## Problem

Installing the Python runtime (issue #65) fails immediately with `spawn tar ENOENT` for some Windows users. All three archive bootstraps (Python runtime, whisper.cpp, demucs.cpp) spawn plain `tar` and rely on the user's `PATH` containing `C:\Windows\System32` — which is not guaranteed; PATH gets mangled by installers/users surprisingly often, while `tar.exe` itself is still present.

## Fix

- Deduplicated the three identical `extractTarGz()` copies into a shared `src/main/strumIntegration/extractTarGz.ts`
- On Windows it now prefers the absolute `%SystemRoot%\System32\tar.exe` path (immune to PATH), falling back to PATH lookup only if that file doesn't exist
- If tar still can't be found, the raw `spawn tar ENOENT` is rewritten into an actionable message telling the user what's missing and how to fix it

## Testing

- New `extractTarGz.test.ts` covering: System32 preference on win32, PATH fallback, ENOENT rewrite, non-ENOENT passthrough — all passing
- `npm run typecheck:node` clean; eslint 0 errors on touched files

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)