### PR TITLE
feat: extend/shrink notes from the keyboard and drag-resize vocal note edges

### DIFF
--- a/src/renderer/src/components/MidiEditor.tsx
+++ b/src/renderer/src/components/MidiEditor.tsx
@@ -1405,6 +1405,7 @@ function VocalNotes({
   onNoteClick,
   onLyricChange,
   onGridMouseDown,
+  onSustainResize,
   starPowerPhrases
 }: {
   vocalNotes: VocalNote[]
@@ -1418,6 +1419,7 @@ function VocalNotes({
   onNoteClick: (noteId: string, modifiers: { ctrl: boolean; shift: boolean; alt: boolean }) => void
   onLyricChange: (noteId: string, lyric: string) => void
   onGridMouseDown: (e: React.MouseEvent<HTMLElement>) => void
+  onSustainResize: (noteId: string, e: React.MouseEvent) => void
   starPowerPhrases: StarPowerPhrase[]
 }): React.JSX.Element {
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -1720,7 +1722,31 @@ function VocalNotes({
     }
   }, [editingLyric, onLyricChange])
 
-  // Cursor: show grab when hovering over a selected vocal note
+  // Mousedown: intercept right-edge resize drags before the grid handler
+  // sees the event (issue #64 — extend existing vocal notes by dragging).
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current
+      if (canvas) {
+        const rect = canvas.getBoundingClientRect()
+        const mx = e.clientX - rect.left
+        const my = e.clientY - rect.top
+        for (let i = visibleNotes.length - 1; i >= 0; i--) {
+          const { note, x, y, w, h } = visibleNotes[i]
+          if (my >= y && my <= y + h && mx >= x + w - SUSTAIN_HANDLE_WIDTH && mx <= x + w + 2) {
+            e.stopPropagation()
+            e.preventDefault()
+            onSustainResize(note.id, e)
+            return
+          }
+        }
+      }
+      onGridMouseDown(e)
+    },
+    [visibleNotes, onSustainResize, onGridMouseDown]
+  )
+
+  // Cursor: ew-resize on note right edge, grab when hovering a selected vocal note
   const handleCursorMove = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
       const canvas = canvasRef.current
@@ -1728,6 +1754,14 @@ function VocalNotes({
       const rect = canvas.getBoundingClientRect()
       const mx = e.clientX - rect.left
       const my = e.clientY - rect.top
+      // Right-edge hover (any note, not just selected)
+      for (let i = visibleNotes.length - 1; i >= 0; i--) {
+        const { x, y, w, h } = visibleNotes[i]
+        if (my >= y && my <= y + h && mx >= x + w - SUSTAIN_HANDLE_WIDTH && mx <= x + w + 2) {
+          canvas.style.cursor = 'ew-resize'
+          return
+        }
+      }
       const selectedSet = new Set(selectedNoteIds)
       if (selectedSet.size === 0) { canvas.style.cursor = ''; return }
       for (let i = visibleNotes.length - 1; i >= 0; i--) {
@@ -1749,7 +1783,7 @@ function VocalNotes({
         className="midi-notes-canvas"
         onClick={handleClick}
         onDoubleClick={handleDoubleClick}
-        onMouseDown={onGridMouseDown}
+        onMouseDown={handleMouseDown}
         onMouseMove={handleCursorMove}
         style={{ pointerEvents: 'auto' }}
       />
@@ -2128,6 +2162,8 @@ function MidiShortcutHelpButton(): React.JSX.Element {
             <div className="shortcut-row"><div className="shortcut-keys"><kbd>{hotkeys.undo}</kbd></div><span className="shortcut-desc">Undo</span></div>
             <div className="shortcut-row"><div className="shortcut-keys"><kbd>{hotkeys.redo}</kbd></div><span className="shortcut-desc">Redo</span></div>
             <div className="shortcut-row"><div className="shortcut-keys"><kbd>{hotkeys.deleteSelection}</kbd></div><span className="shortcut-desc">Delete selected</span></div>
+            <div className="shortcut-row"><div className="shortcut-keys"><kbd>{hotkeys.extendNote}</kbd></div><span className="shortcut-desc">Extend note duration</span></div>
+            <div className="shortcut-row"><div className="shortcut-keys"><kbd>{hotkeys.shrinkNote}</kbd></div><span className="shortcut-desc">Shrink note duration</span></div>
             <div className="shortcut-row"><div className="shortcut-keys"><kbd>{hotkeys.createStarPower}</kbd></div><span className="shortcut-desc">Star Power from selection</span></div>
             <div className="shortcut-row"><div className="shortcut-keys"><kbd>Esc</kbd></div><span className="shortcut-desc">Clear selection</span></div>
           </div>
@@ -3411,6 +3447,28 @@ export function MidiEditor(): React.JSX.Element {
     [songStore]
   )
 
+  // Handle vocal note right-edge resize drag (initiated from VocalNotes canvas)
+  const handleVocalSustainResize = useCallback(
+    (noteId: string, e: React.MouseEvent) => {
+      if (!songStore) return
+      const note = (songStore.getState().song.vocalNotes || []).find((n) => n.id === noteId)
+      if (!note) return
+      const rect = (e.target as HTMLElement).closest('.midi-grid-area')?.getBoundingClientRect()
+      if (!rect) return
+      gridDragRef.current = {
+        mode: 'resize-sustain',
+        startTick: note.tick,
+        startX: e.clientX - rect.left,
+        noteId,
+        instrument: 'vocals',
+        rect,
+        lanes: [],
+        resizeOriginalDuration: note.duration
+      }
+    },
+    [songStore]
+  )
+
   // Handle mousedown on vocal grid - pitch-based note placement
   const handleVocalGridMouseDown = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
@@ -3723,8 +3781,14 @@ export function MidiEditor(): React.JSX.Element {
         }
       } else if (drag.mode === 'resize-sustain' && drag.noteId) {
         const snappedTick = snapToGrid(currentTick, snapDivision, 480)
-        const duration = Math.max(0, snappedTick - drag.startTick)
-        songStore.getState().updateNote(drag.noteId, { duration })
+        if (drag.instrument === 'vocals') {
+          // Floor at one snap division: zero-length vocal notes aren't valid
+          const duration = Math.max(480 / snapDivision, snappedTick - drag.startTick)
+          songStore.getState().updateVocalNote(drag.noteId, { duration })
+        } else {
+          const duration = Math.max(0, snappedTick - drag.startTick)
+          songStore.getState().updateNote(drag.noteId, { duration })
+        }
       } else if (drag.mode === 'select') {
         const startTick = Math.min(drag.startTick, currentTick)
         const endTick = Math.max(drag.startTick, currentTick)
@@ -4400,6 +4464,7 @@ export function MidiEditor(): React.JSX.Element {
                           onNoteClick={handleNoteClick}
                           onLyricChange={(noteId, lyric) => songStore?.getState().updateVocalNote(noteId, { lyric })}
                           onGridMouseDown={handleVocalGridMouseDown}
+                          onSustainResize={handleVocalSustainResize}
                           starPowerPhrases={starPowerPhrases}
                         />
                       ) : isProKeys ? (

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -184,6 +184,32 @@ export function useKeyboardShortcuts(): void {
       if (!isCtrlOrCmd && !isInputElement(e.target as HTMLElement) && songStore) {
         const state = songStore.getState()
 
+        // Shift+Left/Right: extend or shrink selected note durations by one snap division
+        if (matchesHotkey(e, hotkeys.extendNote) || matchesHotkey(e, hotkeys.shrinkNote)) {
+          const snapTicks = 480 / state.snapDivision
+          const delta = matchesHotkey(e, hotkeys.extendNote) ? snapTicks : -snapTicks
+          if (state.selectedNoteIds.length > 0) {
+            e.preventDefault()
+            for (const id of state.selectedNoteIds) {
+              const note = state.song.notes.find((n) => n.id === id)
+              // Floor at 0: a zero-length guitar/bass/keys note is a strum
+              if (note) songStore.getState().updateNote(id, { duration: Math.max(0, note.duration + delta) })
+            }
+            return
+          }
+          if (state.selectedVocalNoteIds.length > 0) {
+            e.preventDefault()
+            for (const id of state.selectedVocalNoteIds) {
+              const note = state.song.vocalNotes.find((n) => n.id === id)
+              // Floor at one snap division: zero-length vocal notes aren't valid
+              if (note) {
+                songStore.getState().updateVocalNote(id, { duration: Math.max(snapTicks, note.duration + delta) })
+              }
+            }
+            return
+          }
+        }
+
         // Left/Right: nudge selected notes (or vocal notes) by one snap division in time
         if (matchesHotkey(e, hotkeys.nudgeLeft) || matchesHotkey(e, hotkeys.nudgeRight)) {
           const snapTicks = 480 / state.snapDivision

--- a/src/renderer/src/stores/projectStore.ts
+++ b/src/renderer/src/stores/projectStore.ts
@@ -126,10 +126,16 @@ export const useSettingsStore = create<SettingsStore>()(
     }),
     {
       name: 'chart-editor-settings',
-      merge: (persisted, current) => ({
-        ...current,
-        ...(persisted as Partial<SettingsStore>)
-      })
+      merge: (persisted, current) => {
+        const persistedSettings = persisted as Partial<SettingsStore>
+        return {
+          ...current,
+          ...persistedSettings,
+          // Deep-merge hotkeys so actions added in newer versions keep their
+          // defaults for users with an older persisted hotkey map.
+          hotkeys: { ...cloneDefaultHotkeys(), ...(persistedSettings?.hotkeys ?? {}) }
+        }
+      }
     }
   )
 )

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -339,6 +339,8 @@ export type HotkeyAction =
   | 'nudgeRight'
   | 'nudgeUp'
   | 'nudgeDown'
+  | 'extendNote'
+  | 'shrinkNote'
   | 'toggleCymbalOrTap'
   | 'toggleGhostOrHopo'
   | 'toggleAccent'

--- a/src/renderer/src/utils/hotkeys.ts
+++ b/src/renderer/src/utils/hotkeys.ts
@@ -22,6 +22,8 @@ export const DEFAULT_HOTKEYS: AppHotkeys = {
   nudgeRight: 'ArrowRight',
   nudgeUp: 'ArrowUp',
   nudgeDown: 'ArrowDown',
+  extendNote: 'Shift+ArrowRight',
+  shrinkNote: 'Shift+ArrowLeft',
   toggleCymbalOrTap: 'S',
   toggleGhostOrHopo: 'G',
   toggleAccent: 'F',
@@ -53,6 +55,8 @@ export const HOTKEY_ACTION_LABELS: Record<HotkeyAction, string> = {
   nudgeRight: 'Nudge Right',
   nudgeUp: 'Nudge Up / Fret +1',
   nudgeDown: 'Nudge Down / Fret -1',
+  extendNote: 'Extend Note Duration',
+  shrinkNote: 'Shrink Note Duration',
   toggleCymbalOrTap: 'Toggle Cymbal/Tap',
   toggleGhostOrHopo: 'Toggle Ghost/HOPO',
   toggleAccent: 'Toggle Accent',
@@ -73,7 +77,7 @@ export const HOTKEY_GROUPS: Array<{ title: string; actions: HotkeyAction[] }> = 
   },
   {
     title: 'Movement',
-    actions: ['nudgeLeft', 'nudgeRight', 'nudgeUp', 'nudgeDown']
+    actions: ['nudgeLeft', 'nudgeRight', 'nudgeUp', 'nudgeDown', 'extendNote', 'shrinkNote']
   },
   {
     title: 'Modifiers',


### PR DESCRIPTION
## Problem (issue #64)

When charting vocals there was no way to change a note's length except typing the tick duration into the property panel:
- Dragging the right edge of an existing vocal note moved the whole note instead of resizing it (the edge-resize interaction only existed on instrument lanes and during initial placement).
- No keyboard shortcut modified duration — Shift+arrows did nothing.

## Changes

**Keyboard** — `Shift+ArrowRight` / `Shift+ArrowLeft` extend/shrink all selected notes by one snap division:
- Works for vocal notes *and* regular instrument notes (guitar/bass/keys/etc.)
- Instrument notes floor at 0 (strum); vocal notes floor at one snap division (zero-length vocal notes aren't valid)
- Rebindable in Settings → Hotkeys (new "Extend/Shrink Note Duration" actions in the Movement group) and documented in the editor's `?` shortcut panel

**Mouse** — vocal notes (talkies included) now support dragging their right edge to resize, with an `ew-resize` cursor on hover. Mirrors the exact interaction and 6px handle the instrument lanes already have; works on any note, selected or not.

**Fix-en-passant** — persisted hotkey maps are now deep-merged with defaults on rehydrate, so hotkey actions added in newer versions (like these two) get their default binding for existing users instead of `undefined`.

## Testing

- `npm run typecheck` clean, eslint 0 errors, all 121 unit tests pass
- Playwright smoke test against the built app (screenshot harness + real C3 song with vocals):
  - placed a vocal note (23px), `Shift+ArrowRight`×4 → 117px ✅
  - `Shift+ArrowLeft`×2 → 69px ✅
  - right-edge drag +80px → 141px ✅

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)