### PR TITLE
release: tar ENOENT runtime-install fix + vocal note duration editing

### DIFF
--- a/src/main/strumIntegration/demucsCppBootstrap.ts
+++ b/src/main/strumIntegration/demucsCppBootstrap.ts
@@ -14,13 +14,13 @@
 // than at app launch.
 
 import { app, BrowserWindow } from 'electron'
-import { execFile } from 'child_process'
 import { existsSync, readFileSync, createWriteStream } from 'fs'
 import { mkdir, rm, writeFile, chmod } from 'fs/promises'
 import { join } from 'path'
 import { pipeline } from 'stream/promises'
 import { Readable } from 'stream'
 import type { AutoChartProgressEvent } from './types'
+import { extractTarGz } from './extractTarGz'
 
 // Bump together with the binary release version. Each bump invalidates
 // the on-disk cache so users get the new binary on next launch.
@@ -172,16 +172,6 @@ async function downloadFile(
     }
   })
   await pipeline(nodeStream, out)
-}
-
-async function extractTarGz(archivePath: string, destDir: string): Promise<void> {
-  await mkdir(destDir, { recursive: true })
-  await new Promise<void>((resolve, reject) => {
-    execFile('tar', ['-xzf', archivePath, '-C', destDir], (err) => {
-      if (err) reject(err)
-      else resolve()
-    })
-  })
 }
 
 let inflight: Promise<{ binaryPath: string; weightsPath: string }> | null = null

--- a/src/main/strumIntegration/extractTarGz.test.ts
+++ b/src/main/strumIntegration/extractTarGz.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const execFileMock = vi.fn()
+const existsSyncMock = vi.fn()
+
+vi.mock('child_process', () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args)
+}))
+
+vi.mock('fs', () => ({
+  existsSync: (...args: unknown[]) => existsSyncMock(...args)
+}))
+
+vi.mock('fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined)
+}))
+
+import { extractTarGz, _resetTarCommandCacheForTests } from './extractTarGz'
+
+function completeWith(err: Error | null): void {
+  execFileMock.mockImplementation((_cmd, _args, cb) => {
+    ;(cb as (err: Error | null) => void)(err)
+  })
+}
+
+describe('extractTarGz', () => {
+  beforeEach(() => {
+    _resetTarCommandCacheForTests()
+    execFileMock.mockReset()
+    existsSyncMock.mockReset()
+  })
+
+  it('prefers the absolute System32 tar.exe on Windows (issue #65: broken PATH)', async () => {
+    if (process.platform !== 'win32') return
+    existsSyncMock.mockReturnValue(true)
+    completeWith(null)
+
+    await extractTarGz('C:\\a.tar.gz', 'C:\\dest')
+
+    const [command, args] = execFileMock.mock.calls[0]
+    expect(command).toMatch(/System32[\\/]tar\.exe$/i)
+    expect(args).toEqual(['-xzf', 'C:\\a.tar.gz', '-C', 'C:\\dest'])
+  })
+
+  it('falls back to PATH lookup when the bundled tar is missing', async () => {
+    existsSyncMock.mockReturnValue(false)
+    completeWith(null)
+
+    await extractTarGz('/a.tar.gz', '/dest')
+
+    expect(execFileMock.mock.calls[0][0]).toBe('tar')
+  })
+
+  it('rewrites spawn ENOENT into an actionable error message', async () => {
+    existsSyncMock.mockReturnValue(false)
+    const enoent = Object.assign(new Error('spawn tar ENOENT'), { code: 'ENOENT' })
+    completeWith(enoent)
+
+    await expect(extractTarGz('/a.tar.gz', '/dest')).rejects.toThrow(
+      /Could not find the "tar" utility/
+    )
+  })
+
+  it('passes through non-ENOENT tar failures unchanged', async () => {
+    existsSyncMock.mockReturnValue(false)
+    completeWith(new Error('tar: corrupted archive'))
+
+    await expect(extractTarGz('/a.tar.gz', '/dest')).rejects.toThrow('tar: corrupted archive')
+  })
+})

--- a/src/main/strumIntegration/extractTarGz.ts
+++ b/src/main/strumIntegration/extractTarGz.ts
@@ -1,0 +1,65 @@
+// Shared .tar.gz extraction for the bootstrap modules (Python runtime,
+// whisper.cpp, demucs.cpp).
+//
+// tar is built into Windows 10 1803+, macOS, and Linux, and `-xzf` works
+// identically across all three. However, spawning plain `tar` relies on the
+// user's PATH containing the right directory (System32 on Windows), and a
+// surprising number of Windows machines have a mangled PATH — which surfaces
+// as `spawn tar ENOENT` (issue #65). To be immune to that, prefer the
+// absolute path to the bundled Windows tar and only fall back to PATH lookup.
+
+import { execFile } from 'child_process'
+import { existsSync } from 'fs'
+import { mkdir } from 'fs/promises'
+import { join } from 'path'
+
+let cachedTarCommand: string | null = null
+
+function resolveTarCommand(): string {
+  if (cachedTarCommand) return cachedTarCommand
+  if (process.platform === 'win32') {
+    const systemRoot = process.env.SystemRoot || process.env.windir || 'C:\\Windows'
+    const systemTar = join(systemRoot, 'System32', 'tar.exe')
+    if (existsSync(systemTar)) {
+      cachedTarCommand = systemTar
+      return systemTar
+    }
+  }
+  cachedTarCommand = 'tar'
+  return cachedTarCommand
+}
+
+/** Extract a .tar.gz archive into destDir (created if missing). */
+export async function extractTarGz(archivePath: string, destDir: string): Promise<void> {
+  await mkdir(destDir, { recursive: true })
+  const tarCommand = resolveTarCommand()
+  await new Promise<void>((resolve, reject) => {
+    execFile(tarCommand, ['-xzf', archivePath, '-C', destDir], (err) => {
+      if (!err) {
+        resolve()
+        return
+      }
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        // tar itself could not be found — give the user something actionable
+        // instead of the cryptic "spawn tar ENOENT".
+        reject(
+          new Error(
+            process.platform === 'win32'
+              ? 'Could not find the "tar" utility needed to extract the downloaded archive. ' +
+                'It ships with Windows 10 (1803+) at C:\\Windows\\System32\\tar.exe. ' +
+                'Please verify that file exists, or reinstall the optional "tar" feature / update Windows, then try again.'
+              : 'Could not find the "tar" utility needed to extract the downloaded archive. ' +
+                'Please install tar via your system package manager and try again.'
+          )
+        )
+        return
+      }
+      reject(err)
+    })
+  })
+}
+
+/** Test-only: reset the cached tar command resolution. */
+export function _resetTarCommandCacheForTests(): void {
+  cachedTarCommand = null
+}

--- a/src/main/strumIntegration/runtimeBootstrap.ts
+++ b/src/main/strumIntegration/runtimeBootstrap.ts
@@ -18,7 +18,7 @@
 // setup from minutes to seconds. This module's public API stays the same.
 
 import { app, BrowserWindow } from 'electron'
-import { execFile, spawn } from 'child_process'
+import { spawn } from 'child_process'
 import { existsSync, readFileSync, createWriteStream } from 'fs'
 import { mkdir, rm, writeFile } from 'fs/promises'
 import { createHash } from 'crypto'
@@ -26,6 +26,7 @@ import { join } from 'path'
 import { pipeline } from 'stream/promises'
 import { Readable } from 'stream'
 import type { AutoChartProgressEvent } from './types'
+import { extractTarGz } from './extractTarGz'
 
 // Pinned python-build-standalone release. Bump in lockstep with
 // requirements.txt if the wheel set requires a newer Python.
@@ -248,18 +249,6 @@ async function downloadFile(url: string, destination: string, runId: string | un
     }
   })
   await pipeline(nodeStream, out)
-}
-
-async function extractTarGz(archivePath: string, destDir: string): Promise<void> {
-  await mkdir(destDir, { recursive: true })
-  // tar is built into Windows 10 1803+, macOS, and Linux. -xzf works
-  // identically across all three.
-  await new Promise<void>((resolve, reject) => {
-    execFile('tar', ['-xzf', archivePath, '-C', destDir], (err) => {
-      if (err) reject(err)
-      else resolve()
-    })
-  })
 }
 
 function runStreaming(

--- a/src/main/strumIntegration/whisperCppBootstrap.ts
+++ b/src/main/strumIntegration/whisperCppBootstrap.ts
@@ -15,13 +15,13 @@
 // users who never chart vocals.
 
 import { app, BrowserWindow } from 'electron'
-import { execFile } from 'child_process'
 import { existsSync, readFileSync, createWriteStream } from 'fs'
 import { mkdir, rm, writeFile, chmod } from 'fs/promises'
 import { join } from 'path'
 import { pipeline } from 'stream/promises'
 import { Readable } from 'stream'
 import type { AutoChartProgressEvent } from './types'
+import { extractTarGz } from './extractTarGz'
 import { detectAccelerator } from './runtimeBootstrap'
 
 // Bump together with the binary release version. Each bump invalidates
@@ -196,16 +196,6 @@ async function downloadFile(
     }
   })
   await pipeline(nodeStream, out)
-}
-
-async function extractTarGz(archivePath: string, destDir: string): Promise<void> {
-  await mkdir(destDir, { recursive: true })
-  await new Promise<void>((resolve, reject) => {
-    execFile('tar', ['-xzf', archivePath, '-C', destDir], (err) => {
-      if (err) reject(err)
-      else resolve()
-    })
-  })
 }
 
 let inflight: Promise<{ binaryPath: string; modelPath: string }> | null = null

--- a/src/renderer/src/components/MidiEditor.tsx
+++ b/src/renderer/src/components/MidiEditor.tsx
@@ -1405,6 +1405,7 @@ function VocalNotes({
   onNoteClick,
   onLyricChange,
   onGridMouseDown,
+  onSustainResize,
   starPowerPhrases
 }: {
   vocalNotes: VocalNote[]
@@ -1418,6 +1419,7 @@ function VocalNotes({
   onNoteClick: (noteId: string, modifiers: { ctrl: boolean; shift: boolean; alt: boolean }) => void
   onLyricChange: (noteId: string, lyric: string) => void
   onGridMouseDown: (e: React.MouseEvent<HTMLElement>) => void
+  onSustainResize: (noteId: string, e: React.MouseEvent) => void
   starPowerPhrases: StarPowerPhrase[]
 }): React.JSX.Element {
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -1720,7 +1722,31 @@ function VocalNotes({
     }
   }, [editingLyric, onLyricChange])
 
-  // Cursor: show grab when hovering over a selected vocal note
+  // Mousedown: intercept right-edge resize drags before the grid handler
+  // sees the event (issue #64 — extend existing vocal notes by dragging).
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current
+      if (canvas) {
+        const rect = canvas.getBoundingClientRect()
+        const mx = e.clientX - rect.left
+        const my = e.clientY - rect.top
+        for (let i = visibleNotes.length - 1; i >= 0; i--) {
+          const { note, x, y, w, h } = visibleNotes[i]
+          if (my >= y && my <= y + h && mx >= x + w - SUSTAIN_HANDLE_WIDTH && mx <= x + w + 2) {
+            e.stopPropagation()
+            e.preventDefault()
+            onSustainResize(note.id, e)
+            return
+          }
+        }
+      }
+      onGridMouseDown(e)
+    },
+    [visibleNotes, onSustainResize, onGridMouseDown]
+  )
+
+  // Cursor: ew-resize on note right edge, grab when hovering a selected vocal note
   const handleCursorMove = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
       const canvas = canvasRef.current
@@ -1728,6 +1754,14 @@ function VocalNotes({
       const rect = canvas.getBoundingClientRect()
       const mx = e.clientX - rect.left
       const my = e.clientY - rect.top
+      // Right-edge hover (any note, not just selected)
+      for (let i = visibleNotes.length - 1; i >= 0; i--) {
+        const { x, y, w, h } = visibleNotes[i]
+        if (my >= y && my <= y + h && mx >= x + w - SUSTAIN_HANDLE_WIDTH && mx <= x + w + 2) {
+          canvas.style.cursor = 'ew-resize'
+          return
+        }
+      }
       const selectedSet = new Set(selectedNoteIds)
       if (selectedSet.size === 0) { canvas.style.cursor = ''; return }
       for (let i = visibleNotes.length - 1; i >= 0; i--) {
@@ -1749,7 +1783,7 @@ function VocalNotes({
         className="midi-notes-canvas"
         onClick={handleClick}
         onDoubleClick={handleDoubleClick}
-        onMouseDown={onGridMouseDown}
+        onMouseDown={handleMouseDown}
         onMouseMove={handleCursorMove}
         style={{ pointerEvents: 'auto' }}
       />
@@ -2128,6 +2162,8 @@ function MidiShortcutHelpButton(): React.JSX.Element {
             <div className="shortcut-row"><div className="shortcut-keys"><kbd>{hotkeys.undo}</kbd></div><span className="shortcut-desc">Undo</span></div>
             <div className="shortcut-row"><div className="shortcut-keys"><kbd>{hotkeys.redo}</kbd></div><span className="shortcut-desc">Redo</span></div>
             <div className="shortcut-row"><div className="shortcut-keys"><kbd>{hotkeys.deleteSelection}</kbd></div><span className="shortcut-desc">Delete selected</span></div>
+            <div className="shortcut-row"><div className="shortcut-keys"><kbd>{hotkeys.extendNote}</kbd></div><span className="shortcut-desc">Extend note duration</span></div>
+            <div className="shortcut-row"><div className="shortcut-keys"><kbd>{hotkeys.shrinkNote}</kbd></div><span className="shortcut-desc">Shrink note duration</span></div>
             <div className="shortcut-row"><div className="shortcut-keys"><kbd>{hotkeys.createStarPower}</kbd></div><span className="shortcut-desc">Star Power from selection</span></div>
             <div className="shortcut-row"><div className="shortcut-keys"><kbd>Esc</kbd></div><span className="shortcut-desc">Clear selection</span></div>
           </div>
@@ -3411,6 +3447,28 @@ export function MidiEditor(): React.JSX.Element {
     [songStore]
   )
 
+  // Handle vocal note right-edge resize drag (initiated from VocalNotes canvas)
+  const handleVocalSustainResize = useCallback(
+    (noteId: string, e: React.MouseEvent) => {
+      if (!songStore) return
+      const note = (songStore.getState().song.vocalNotes || []).find((n) => n.id === noteId)
+      if (!note) return
+      const rect = (e.target as HTMLElement).closest('.midi-grid-area')?.getBoundingClientRect()
+      if (!rect) return
+      gridDragRef.current = {
+        mode: 'resize-sustain',
+        startTick: note.tick,
+        startX: e.clientX - rect.left,
+        noteId,
+        instrument: 'vocals',
+        rect,
+        lanes: [],
+        resizeOriginalDuration: note.duration
+      }
+    },
+    [songStore]
+  )
+
   // Handle mousedown on vocal grid - pitch-based note placement
   const handleVocalGridMouseDown = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
@@ -3723,8 +3781,14 @@ export function MidiEditor(): React.JSX.Element {
         }
       } else if (drag.mode === 'resize-sustain' && drag.noteId) {
         const snappedTick = snapToGrid(currentTick, snapDivision, 480)
-        const duration = Math.max(0, snappedTick - drag.startTick)
-        songStore.getState().updateNote(drag.noteId, { duration })
+        if (drag.instrument === 'vocals') {
+          // Floor at one snap division: zero-length vocal notes aren't valid
+          const duration = Math.max(480 / snapDivision, snappedTick - drag.startTick)
+          songStore.getState().updateVocalNote(drag.noteId, { duration })
+        } else {
+          const duration = Math.max(0, snappedTick - drag.startTick)
+          songStore.getState().updateNote(drag.noteId, { duration })
+        }
       } else if (drag.mode === 'select') {
         const startTick = Math.min(drag.startTick, currentTick)
         const endTick = Math.max(drag.startTick, currentTick)
@@ -4400,6 +4464,7 @@ export function MidiEditor(): React.JSX.Element {
                           onNoteClick={handleNoteClick}
                           onLyricChange={(noteId, lyric) => songStore?.getState().updateVocalNote(noteId, { lyric })}
                           onGridMouseDown={handleVocalGridMouseDown}
+                          onSustainResize={handleVocalSustainResize}
                           starPowerPhrases={starPowerPhrases}
                         />
                       ) : isProKeys ? (

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -184,6 +184,32 @@ export function useKeyboardShortcuts(): void {
       if (!isCtrlOrCmd && !isInputElement(e.target as HTMLElement) && songStore) {
         const state = songStore.getState()
 
+        // Shift+Left/Right: extend or shrink selected note durations by one snap division
+        if (matchesHotkey(e, hotkeys.extendNote) || matchesHotkey(e, hotkeys.shrinkNote)) {
+          const snapTicks = 480 / state.snapDivision
+          const delta = matchesHotkey(e, hotkeys.extendNote) ? snapTicks : -snapTicks
+          if (state.selectedNoteIds.length > 0) {
+            e.preventDefault()
+            for (const id of state.selectedNoteIds) {
+              const note = state.song.notes.find((n) => n.id === id)
+              // Floor at 0: a zero-length guitar/bass/keys note is a strum
+              if (note) songStore.getState().updateNote(id, { duration: Math.max(0, note.duration + delta) })
+            }
+            return
+          }
+          if (state.selectedVocalNoteIds.length > 0) {
+            e.preventDefault()
+            for (const id of state.selectedVocalNoteIds) {
+              const note = state.song.vocalNotes.find((n) => n.id === id)
+              // Floor at one snap division: zero-length vocal notes aren't valid
+              if (note) {
+                songStore.getState().updateVocalNote(id, { duration: Math.max(snapTicks, note.duration + delta) })
+              }
+            }
+            return
+          }
+        }
+
         // Left/Right: nudge selected notes (or vocal notes) by one snap division in time
         if (matchesHotkey(e, hotkeys.nudgeLeft) || matchesHotkey(e, hotkeys.nudgeRight)) {
           const snapTicks = 480 / state.snapDivision

--- a/src/renderer/src/stores/projectStore.ts
+++ b/src/renderer/src/stores/projectStore.ts
@@ -126,10 +126,16 @@ export const useSettingsStore = create<SettingsStore>()(
     }),
     {
       name: 'chart-editor-settings',
-      merge: (persisted, current) => ({
-        ...current,
-        ...(persisted as Partial<SettingsStore>)
-      })
+      merge: (persisted, current) => {
+        const persistedSettings = persisted as Partial<SettingsStore>
+        return {
+          ...current,
+          ...persistedSettings,
+          // Deep-merge hotkeys so actions added in newer versions keep their
+          // defaults for users with an older persisted hotkey map.
+          hotkeys: { ...cloneDefaultHotkeys(), ...(persistedSettings?.hotkeys ?? {}) }
+        }
+      }
     }
   )
 )

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -339,6 +339,8 @@ export type HotkeyAction =
   | 'nudgeRight'
   | 'nudgeUp'
   | 'nudgeDown'
+  | 'extendNote'
+  | 'shrinkNote'
   | 'toggleCymbalOrTap'
   | 'toggleGhostOrHopo'
   | 'toggleAccent'

--- a/src/renderer/src/utils/hotkeys.ts
+++ b/src/renderer/src/utils/hotkeys.ts
@@ -22,6 +22,8 @@ export const DEFAULT_HOTKEYS: AppHotkeys = {
   nudgeRight: 'ArrowRight',
   nudgeUp: 'ArrowUp',
   nudgeDown: 'ArrowDown',
+  extendNote: 'Shift+ArrowRight',
+  shrinkNote: 'Shift+ArrowLeft',
   toggleCymbalOrTap: 'S',
   toggleGhostOrHopo: 'G',
   toggleAccent: 'F',
@@ -53,6 +55,8 @@ export const HOTKEY_ACTION_LABELS: Record<HotkeyAction, string> = {
   nudgeRight: 'Nudge Right',
   nudgeUp: 'Nudge Up / Fret +1',
   nudgeDown: 'Nudge Down / Fret -1',
+  extendNote: 'Extend Note Duration',
+  shrinkNote: 'Shrink Note Duration',
   toggleCymbalOrTap: 'Toggle Cymbal/Tap',
   toggleGhostOrHopo: 'Toggle Ghost/HOPO',
   toggleAccent: 'Toggle Accent',
@@ -73,7 +77,7 @@ export const HOTKEY_GROUPS: Array<{ title: string; actions: HotkeyAction[] }> = 
   },
   {
     title: 'Movement',
-    actions: ['nudgeLeft', 'nudgeRight', 'nudgeUp', 'nudgeDown']
+    actions: ['nudgeLeft', 'nudgeRight', 'nudgeUp', 'nudgeDown', 'extendNote', 'shrinkNote']
   },
   {
     title: 'Modifiers',


### PR DESCRIPTION
Promotes beta to stable. Contains:

- #66 — fix: resolve tar by absolute path on Windows so the Python runtime / whisper.cpp / demucs.cpp installs survive a broken PATH (fixes #65)
- #67 — feat: extend/shrink note durations with Shift+ArrowRight/Left and drag-resize vocal note right edges (fixes #64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)